### PR TITLE
mac: Set a valid interface number on hid_device_info for USB HID dev…

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -69,9 +69,13 @@ extern "C" {
 			    (Windows/Mac only).*/
 			unsigned short usage;
 			/** The USB interface which this logical device
-			    represents. Valid on both Linux implementations
-			    in all cases, and valid on the Windows implementation
-			    only if the device contains more than one interface. */
+			    represents.
+
+				* Valid on both Linux implementations in all cases.
+				* Valid on the Windows implementation only if the device
+				  contains more than one interface.
+				* Valid on the Mac implementation if and only if the device
+				  is a USB HID device. */
 			int interface_number;
 
 			/** Pointer to the next device */

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -25,6 +25,7 @@
 #include <IOKit/hid/IOHIDManager.h>
 #include <IOKit/hid/IOHIDKeys.h>
 #include <IOKit/IOKitLib.h>
+#include <IOKit/usb/USBSpec.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <wchar.h>
 #include <locale.h>
@@ -432,6 +433,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		if ((vendor_id == 0x0 || vendor_id == dev_vid) &&
 		    (product_id == 0x0 || product_id == dev_pid)) {
 			struct hid_device_info *tmp;
+			bool is_usb_hid; /* Is this an actual HID usb device */
 			io_object_t iokit_dev;
 			kern_return_t res;
 			io_string_t path;
@@ -445,6 +447,8 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 				root = tmp;
 			}
 			cur_dev = tmp;
+
+			is_usb_hid = get_int_property(dev, CFSTR(kUSBInterfaceClass)) == kUSBHIDClass;
 
 			/* Get the Usage Page and Usage for this device. */
 			cur_dev->usage_page = get_int_property(dev, CFSTR(kIOHIDPrimaryUsagePageKey));
@@ -478,8 +482,15 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			/* Release Number */
 			cur_dev->release_number = get_int_property(dev, CFSTR(kIOHIDVersionNumberKey));
 
-			/* Interface Number (Unsupported on Mac)*/
-			cur_dev->interface_number = -1;
+			/* We can only retrieve the interface number for USB HID devices.
+			 * IOKit always seems to return 0 when querying a standard USB device
+			 * for its interface. */
+			if (is_usb_hid) {
+				/* Get the interface number */
+				cur_dev->interface_number = get_int_property(dev, CFSTR(kUSBInterfaceNumber));
+			} else {
+				cur_dev->interface_number = -1;
+			}
 		}
 	}
 


### PR DESCRIPTION
…ices

Previously the interface would never be set on Mac.

This presents a big pain because retrieving interface numbers can be the
only way to distinguish between the interfaces returned by HIDAPI.

This change makes it possible to retrieve interface number from an
hid_device_info on Mac for USB HID devices only.

It is unclear if the Mac OS IOKit library returns valid interface numbers for non-HID USB devices. Because of this, I have opted to simply skip that case - leave it initialised to `-1`.

In the future, we can easily relax this restriction if it turns out IOKit correctly returns interface number with non-HID USB devices. For now, this PR brings 90% of the value at 5% of the risk.

Re-open of signal11/hidapi#380