### PR TITLE
README.txt: update number of backends

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,7 +10,7 @@ OS X.  HIDAPI can be either built as a shared library (.so or .dll) or
 can be embedded directly into a target application by adding a single source
 file (per platform) and a single header.
 
-HIDAPI has four back-ends:
+HIDAPI has five back-ends:
 	* Windows (using hid.dll)
 	* Linux/hidraw (using the Kernel's hidraw driver)
 	* Linux/libusb (using libusb-1.0)


### PR DESCRIPTION
FreeBSD support was added in commit 74440e2d as the fifth back-end, but
the list was still introduced as "HIDAPI has four back-ends."