### PR TITLE
hidtest: report VID and PID in hid_open failure message

### DIFF
--- a/hidtest/hidtest.cpp
+++ b/hidtest/hidtest.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 	////handle = hid_open(0x4d8, 0x3f, L"12345");
 	handle = hid_open(0x4d8, 0x3f, NULL);
 	if (!handle) {
-		printf("unable to open device\n");
+		printf("unable to open device %04x:%04x\n", 0x4d8, 0x3f);
  		return 1;
 	}
 


### PR DESCRIPTION
hidtest attempts to open a device with VID:PID 04d8:00x3f and previously
reported just "unable to open device" if that device was not found.
Include the VID:PID in the error message to clarify the issue.