### PR TITLE
Update Makefile.am after README.md

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,7 @@ endif
 EXTRA_DIST = udev doxygen
 
 dist_doc_DATA = \
- README.txt \
+ README.md \
  AUTHORS.txt \
  LICENSE-bsd.txt \
  LICENSE-gpl3.txt \


### PR DESCRIPTION
The 'make' build on Linux/MacOS generates an error since README.txt was renamed to README.md. See #17 .