### PR TITLE
hidraw: Implement hid_error()

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -151,6 +151,8 @@ extern "C" {
 			If @p serial_number is NULL, the first device with the
 			specified VID and PID is opened.
 
+			This function sets the return value of hid_error().
+
 			@ingroup API
 			@param vendor_id The Vendor ID (VID) of the device to open.
 			@param product_id The Product ID (PID) of the device to open.
@@ -168,6 +170,8 @@ extern "C" {
 			The path name be determined by calling hid_enumerate(), or a
 			platform-specific path name can be used (eg: /dev/hidraw0 on
 			Linux).
+
+			This function sets the return value of hid_error().
 
 			@ingroup API
 		    @param path The path name of the device to open
@@ -194,6 +198,8 @@ extern "C" {
 			one exists. If it does not, it will send the data through
 			the Control Endpoint (Endpoint 0).
 
+			This function sets the return value of hid_error().
+
 			@ingroup API
 			@param dev A device handle returned from hid_open().
 			@param data The data to send, including the report number as
@@ -211,6 +217,8 @@ extern "C" {
 			Input reports are returned
 			to the host through the INTERRUPT IN endpoint. The first byte will
 			contain the Report number if the device uses numbered reports.
+
+			This function sets the return value of hid_error().
 
 			@ingroup API
 			@param dev A device handle returned from hid_open().
@@ -232,6 +240,8 @@ extern "C" {
 			Input reports are returned
 		    to the host through the INTERRUPT IN endpoint. The first byte will
 			contain the Report number if the device uses numbered reports.
+
+			This function sets the return value of hid_error().
 
 			@ingroup API
 			@param dev A device handle returned from hid_open().
@@ -282,6 +292,8 @@ extern "C" {
 			report data (16 bytes). In this example, the length passed
 			in would be 17.
 
+			This function sets the return value of hid_error().
+
 			@ingroup API
 			@param dev A device handle returned from hid_open().
 			@param data The data to send, including the report number as
@@ -303,6 +315,8 @@ extern "C" {
 			still contain the Report ID, and the report data will
 			start in data[1].
 
+			This function sets the return value of hid_error().
+
 			@ingroup API
 			@param dev A device handle returned from hid_open().
 			@param data A buffer to put the read data into, including
@@ -321,6 +335,8 @@ extern "C" {
 		int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length);
 
 		/** @brief Close a HID device.
+
+			This function sets the return value of hid_error().
 
 			@ingroup API
 			@param dev A device handle returned from hid_open().
@@ -378,8 +394,18 @@ extern "C" {
 
 		/** @brief Get a string describing the last error which occurred.
 
+			Whether a function sets the last error is noted in its
+			documentation. These functions will reset the last error
+			to NULL before their execution.
+
+			Strings returned from hid_error() must not be freed by the user!
+
+			This function is thread-safe, and error messages are thread-local.
+
 			@ingroup API
-			@param dev A device handle returned from hid_open().
+			@param dev A device handle returned from hid_open(),
+			  or NULL to get the last non-device-specific error
+			  (e.g. for errors in hid_open() itself).
 
 			@returns
 				This function returns a string containing the last error

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1298,7 +1298,7 @@ int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index
 
 HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 {
-	return NULL;
+	return L"hid_error is not implemented yet";
 }
 
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -75,8 +75,12 @@ struct hid_device_ {
 	int device_handle;
 	int blocking;
 	int uses_numbered_reports;
+	wchar_t *last_error_str;
 };
 
+/* Global error message that is not specific to a device, e.g. for
+   hid_open(). It is thread-local like errno. */
+__thread wchar_t *last_global_error_str = NULL;
 
 static __u32 kernel_version = 0;
 
@@ -107,6 +111,7 @@ static hid_device *new_hid_device(void)
 	dev->device_handle = -1;
 	dev->blocking = 1;
 	dev->uses_numbered_reports = 0;
+	dev->last_error_str = NULL;
 
 	return dev;
 }
@@ -128,6 +133,48 @@ static wchar_t *utf8_to_wchar_t(const char *utf8)
 	}
 
 	return ret;
+}
+
+
+/* Set the last global error to be reported by hid_error(NULL).
+ * The given error message will be copied (and decoded according to the
+ * currently locale, so do not pass in string constants).
+ * The last stored global error message is freed.
+ * Use register_global_error(NULL) to indicate "no error". */
+static void register_global_error(const char *msg)
+{
+	if (last_global_error_str)
+		free(last_global_error_str);
+
+	last_global_error_str = utf8_to_wchar_t(msg);
+}
+
+
+/* Set the last error for a device to be reported by hid_error(device).
+ * The given error message will be copied (and decoded according to the
+ * currently locale, so do not pass in string constants).
+ * The last stored global error message is freed.
+ * Use register_device_error(device, NULL) to indicate "no error". */
+static void register_device_error(hid_device *dev, const char *msg)
+{
+	if (dev->last_error_str)
+		free(dev->last_error_str);
+
+	dev->last_error_str = utf8_to_wchar_t(msg);
+}
+
+/* See register_device_error, but you can pass a format string into this function. */
+static void register_device_error_format(hid_device *dev, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+
+	char msg[100];
+	vsnprintf(msg, sizeof(msg), format, args);
+
+	va_end(args);
+
+	register_device_error(dev, msg);
 }
 
 /* Get an attribute value from a udev_device and return it as a whar_t
@@ -269,7 +316,7 @@ static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t
 	/* Create the udev object */
 	udev = udev_new();
 	if (!udev) {
-		printf("Can't create udev\n");
+		register_global_error("Couldn't create udev context");
 		return -1;
 	}
 
@@ -375,7 +422,9 @@ int HID_API_EXPORT hid_init(void)
 
 int HID_API_EXPORT hid_exit(void)
 {
-	/* Nothing to do for this in the Linux/hidraw implementation. */
+	/* Free global error message */
+	register_global_error(NULL);
+
 	return 0;
 }
 
@@ -395,7 +444,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	/* Create the udev object */
 	udev = udev_new();
 	if (!udev) {
-		printf("Can't create udev\n");
+		register_global_error("Couldn't create udev context");
 		return NULL;
 	}
 
@@ -584,6 +633,9 @@ void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
 
 hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
 {
+	/* Set global error to none */
+	register_global_error(NULL);
+
 	struct hid_device_info *devs, *cur_dev;
 	const char *path_to_open = NULL;
 	hid_device *handle = NULL;
@@ -610,6 +662,8 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const
 	if (path_to_open) {
 		/* Open the device */
 		handle = hid_open_path(path_to_open);
+	} else {
+		register_global_error("No such device");
 	}
 
 	hid_free_enumeration(devs);
@@ -619,6 +673,9 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const
 
 hid_device * HID_API_EXPORT hid_open_path(const char *path)
 {
+	/* Set global error to none */
+	register_global_error(NULL);
+
 	hid_device *dev = NULL;
 
 	hid_init();
@@ -630,6 +687,8 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 	/* If we have a good handle, return it. */
 	if (dev->device_handle > 0) {
+		/* Set device error to none */
+		register_device_error(dev, NULL);
 
 		/* Get the report descriptor */
 		int res, desc_size = 0;
@@ -640,14 +699,13 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		/* Get Report Descriptor Size */
 		res = ioctl(dev->device_handle, HIDIOCGRDESCSIZE, &desc_size);
 		if (res < 0)
-			perror("HIDIOCGRDESCSIZE");
-
+			register_device_error_format(dev, "ioctl (GRDESCSIZE): %s", strerror(errno));
 
 		/* Get Report Descriptor */
 		rpt_desc.size = desc_size;
 		res = ioctl(dev->device_handle, HIDIOCGRDESC, &rpt_desc);
 		if (res < 0) {
-			perror("HIDIOCGRDESC");
+			register_device_error_format(dev, "ioctl (GRDESC): %s", strerror(errno));
 		} else {
 			/* Determine if this device uses numbered reports. */
 			dev->uses_numbered_reports =
@@ -659,6 +717,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 	}
 	else {
 		/* Unable to open any devices. */
+		register_global_error(strerror(errno));
 		free(dev);
 		return NULL;
 	}
@@ -671,12 +730,17 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 
 	bytes_written = write(dev->device_handle, data, length);
 
+	register_device_error(dev, (bytes_written == -1)? strerror(errno): NULL);
+
 	return bytes_written;
 }
 
 
 int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds)
 {
+	/* Set device error to none */
+	register_device_error(dev, NULL);
+
 	int bytes_read;
 
 	if (milliseconds >= 0) {
@@ -693,21 +757,31 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 		fds.events = POLLIN;
 		fds.revents = 0;
 		ret = poll(&fds, 1, milliseconds);
-		if (ret == -1 || ret == 0) {
-			/* Error or timeout */
+		if (ret == 0) {
+			/* Timeout */
+			return ret;
+		}
+		if (ret == -1) {
+			/* Error */
+			register_device_error(dev, strerror(errno));
 			return ret;
 		}
 		else {
 			/* Check for errors on the file descriptor. This will
 			   indicate a device disconnection. */
 			if (fds.revents & (POLLERR | POLLHUP | POLLNVAL))
+				// We cannot use strerror() here as no -1 was returned from poll().
 				return -1;
 		}
 	}
 
 	bytes_read = read(dev->device_handle, data, length);
-	if (bytes_read < 0 && (errno == EAGAIN || errno == EINPROGRESS))
-		bytes_read = 0;
+	if (bytes_read < 0) {
+		if (errno == EAGAIN || errno == EINPROGRESS)
+			bytes_read = 0;
+		else
+			register_device_error(dev, strerror(errno));
+	}
 
 	if (bytes_read >= 0 &&
 	    kernel_version != 0 &&
@@ -743,7 +817,7 @@ int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char 
 
 	res = ioctl(dev->device_handle, HIDIOCSFEATURE(length), data);
 	if (res < 0)
-		perror("ioctl (SFEATURE)");
+		register_device_error_format(dev, "ioctl (SFEATURE): %s", strerror(errno));
 
 	return res;
 }
@@ -754,8 +828,7 @@ int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, 
 
 	res = ioctl(dev->device_handle, HIDIOCGFEATURE(length), data);
 	if (res < 0)
-		perror("ioctl (GFEATURE)");
-
+		register_device_error_format(dev, "ioctl (GFEATURE): %s", strerror(errno));
 
 	return res;
 }
@@ -765,7 +838,14 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 {
 	if (!dev)
 		return;
-	close(dev->device_handle);
+
+	int ret = close(dev->device_handle);
+
+	register_global_error((ret == -1)? strerror(errno): NULL);
+
+	/* Free the device error message */
+	register_device_error(dev, NULL);
+
 	free(dev);
 }
 
@@ -791,7 +871,16 @@ int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index
 }
 
 
+/* Passing in NULL means asking for the last global error message. */
 HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 {
-	return NULL;
+	if (dev) {
+		if (dev->last_error_str == NULL)
+			return L"Success";
+		return dev->last_error_str;
+	}
+
+	if (last_global_error_str == NULL)
+		return L"Success";
+	return last_global_error_str;
 }

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1045,7 +1045,7 @@ HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 {
 	/* TODO: */
 
-	return NULL;
+	return L"hid_error is not implemented yet";
 }
 
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -881,7 +881,14 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_indexed_string(hid_device *dev, int
 
 HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 {
-	return (wchar_t*)dev->last_error_str;
+	if (dev) {
+		if (dev->last_error_str == NULL)
+			return L"Success";
+		return (wchar_t*)dev->last_error_str;
+	}
+
+	// Global error messages are not (yet) implemented on Windows.
+	return L"hid_error for global errors is not implemented yet";
 }
 
 


### PR DESCRIPTION
Here is my first try at implementing error messages for the Linux/hidraw implementation.

* I used a thread-local variable for non-device error messages.
* Non-device errors can be obtained by passing `NULL` into `hid_error` as I suggested in #123.
* I **belive** to have covered all system calls that could fail; please check this.

A few extra questions:

* I am not sure why in `utf8_to_wchar_t` the input is called `utf8`. As far as I know, the encoding used in `mbstowcs` depends on the current locale, if if I haven't set my locale to use UTF8, then the input is not UTF8.
* The `register_error` equivalent in `windows/hid.c` doesn't use its argument `const char *op`. Is that intended?
* In the Windows implementation, do functions like [`HidD_GetPreparsedData`](http://msdn.microsoft.com/en-us/library/windows/hardware/ff539679%28v=vs.85%29.aspx) actually set the error code for `GetLastError()`?

Originally https://github.com/signal11/hidapi/pull/125