### PR TITLE
WIP: Support for OpenBSD

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,0 +1,20 @@
+image: openbsd/6.5
+packages:
+- autoconf-2.69p2
+- automake-1.16.1
+- libiconv
+- libtool
+- libusb1
+sources:
+- https://github.com/libusb/hidapi
+tasks:
+- setup: |
+    cd hidapi
+    export AUTOCONF_VERSION=2.69
+    export AUTOMAKE_VERSION=1.16
+    ./bootstrap
+    ./configure
+- build: |
+    cd hidapi
+    make
+    make DESTDIR=$PWD/root install

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,10 @@ if OS_KFREEBSD
 SUBDIRS += libusb
 endif
 
+if OS_OPENBSD
+SUBDIRS += libusb
+endif
+
 if OS_WINDOWS
 SUBDIRS += windows
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,21 @@ case $host in
 	AC_CHECK_LIB([usb], [libusb_init], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -lusb"], [hidapi_lib_error libusb])
 	echo libs_priv: $LIBS_LIBUSB_PRIVATE
 	;;
+*-openbsd*)
+	AC_MSG_RESULT([ (OpenBSD back-end)])
+	AC_DEFINE(OS_OPENBSD, 1, [OpenBSD implementation])
+	AC_SUBST(OS_OPENBSD)
+	backend="libusb"
+	os="openbsd"
+	threads="pthreads"
+
+	CFLAGS="$CFLAGS -I/usr/local/include"
+	LDFLAGS="$LDFLAGS -L/usr/local/lib"
+	PKG_CHECK_MODULES([libusb], [libusb-1.0 >= 1.0.9], true, [hidapi_lib_error libusb-1.0])
+	LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} $libusb_LIBS"
+	CFLAGS_LIBUSB="${CFLAGS_LIBUSB} $libusb_CFLAGS"
+	AC_CHECK_LIB([iconv], [libiconv_open], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -liconv"], [hidapi_lib_error libiconv])
+	;;
 *-mingw*)
 	AC_MSG_RESULT([ (Windows back-end, using MinGW)])
 	backend="windows"
@@ -213,6 +228,7 @@ AM_CONDITIONAL(OS_LINUX, test "x$os" = xlinux)
 AM_CONDITIONAL(OS_DARWIN, test "x$os" = xdarwin)
 AM_CONDITIONAL(OS_FREEBSD, test "x$os" = xfreebsd)
 AM_CONDITIONAL(OS_KFREEBSD, test "x$os" = xkfreebsd)
+AM_CONDITIONAL(OS_OPENBSD, test "x$os" = xopenbsd)
 AM_CONDITIONAL(OS_WINDOWS, test "x$os" = xwindows)
 
 AC_CONFIG_HEADERS([config.h])

--- a/libusb/Makefile.am
+++ b/libusb/Makefile.am
@@ -21,6 +21,13 @@ libhidapi_la_LDFLAGS = $(LTLDFLAGS)
 libhidapi_la_LIBADD = $(LIBS_LIBUSB)
 endif
 
+if OS_OPENBSD
+lib_LTLIBRARIES = libhidapi.la
+libhidapi_la_SOURCES = hid.c
+libhidapi_la_LDFLAGS = $(LTLDFLAGS)
+libhidapi_la_LIBADD = $(LIBS_LIBUSB)
+endif
+
 hdrdir = $(includedir)/hidapi
 hdr_HEADERS = $(top_srcdir)/hidapi/hidapi.h
 


### PR DESCRIPTION
OpenBSD currently have a patchset on hidapi in their repos but it was pretty unusable for upstream.

This is proper support for OpenBSD and it compiles: https://builds.sr.ht/~z3ntu/job/70849 . Should be tested with an actual application as well.

An interesting note from the OpenBSD ports:

> rename hid_init() to hidapi_hid_init() to avoid collision with usbhid

What they mean is that a library in OpenBSD https://man.openbsd.org/usbhid.3 already has the name `hid_init`. No idea how that can be solved cleanly.