### PR TITLE
Add ar-lib & compile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 # Autotools-added generated files
 Makefile.in
 aclocal.m4
+ar-lib
 autom4te.cache/
 config.*
 configure
+compile
 depcomp
 install-sh
 libusb/Makefile.in


### PR DESCRIPTION
This should result in no untracked files being present in the working directory when `./bootstrap` was run