### PR TITLE
Fix compile warning on FreeBSD

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -397,11 +397,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	size_t inbytes;
 	size_t outbytes;
 	size_t res;
-#ifdef __FreeBSD__
-	const char *inptr;
-#else
 	char *inptr;
-#endif
 	char *outptr;
 #endif
 


### PR DESCRIPTION
```
hid.c:458:18: warning: passing 'const char **' to parameter of type 'char **' discards qualifiers in nested pointer types
      [-Wincompatible-pointer-types-discards-qualifiers]
        res = iconv(ic, &inptr, &inbytes, &outptr, &outbytes);
                        ^~~~~~
/usr/local/include/iconv.h:85:43: note: passing argument to parameter 'inbuf' here
extern size_t iconv (iconv_t cd,  char* * inbuf, size_t *inbytesleft, char* * outbuf, size_t *outbytesleft);
                                          ^
1 warning generated.
```

I'm not sure why this `#ifdef` existed but it compiles fine on FreeBSD 12 with this change (and gets rid of the warning).