### PR TITLE
testgui: fix compile warnings on macOS

### DIFF
--- a/testgui/mac_support_cocoa.m
+++ b/testgui/mac_support_cocoa.m
@@ -8,6 +8,15 @@
 #include <fx.h>
 #import <Cocoa/Cocoa.h>
 
+#ifndef MAC_OS_X_VERSION_10_12
+#define MAC_OS_X_VERSION_10_12 101200
+#endif
+
+// macOS 10.12 deprecated NSAnyEventMask in favor of NSEventMaskAny
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
+#define NSEventMaskAny NSAnyEventMask
+#endif
+
 extern FXMainWindow *g_main_window;
 
 
@@ -77,7 +86,7 @@ check_apple_events()
 
 	NSAutoreleasePool *pool = [NSAutoreleasePool new];
 	while (1) {
-		NSEvent* event = [NSApp nextEventMatchingMask:NSAnyEventMask
+		NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny
 		                        untilDate:nil
                                         inMode:NSDefaultRunLoopMode
                                         dequeue:YES];

--- a/testgui/mac_support_cocoa.m
+++ b/testgui/mac_support_cocoa.m
@@ -20,7 +20,7 @@
 extern FXMainWindow *g_main_window;
 
 
-@interface MyAppDelegate : NSObject
+@interface MyAppDelegate : NSObject<NSApplicationDelegate>
 {
 } 
 @end


### PR DESCRIPTION
The first commit should be backwards compatible (< 10.12), as I've added a define for the old type.

The second commit I'm not sure about, from what I could fine it was an API change in NSApplication in macOS 10.10, so it might not compile on versions before that?