### PR TITLE
Zero-initialize new hid_device_info structs

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -476,7 +476,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			struct hid_device_info *tmp;
 
 			/* VID/PID match. Create the record. */
-			tmp = (struct hid_device_info*) malloc(sizeof(struct hid_device_info));
+			tmp = (struct hid_device_info*) calloc(1, sizeof(struct hid_device_info));
 			if (cur_dev) {
 				cur_dev->next = tmp;
 			}

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -440,7 +440,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			io_string_t path;
 
 			/* VID/PID match. Create the record. */
-			tmp = (struct hid_device_info*) malloc(sizeof(struct hid_device_info));
+			tmp = (struct hid_device_info*) calloc(1, sizeof(struct hid_device_info));
 			if (cur_dev) {
 				cur_dev->next = tmp;
 			}


### PR DESCRIPTION
This fixes an uninitialized usage_page value leaking from the Linux
backend. It may fix other uninitialized values, too.