### PR TITLE
support multipe usage/usage-pairs on MacOS

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -46,7 +46,7 @@ extern "C" {
 		typedef struct hid_device_ hid_device; /**< opaque hidapi structure */
 
 		/** hidapi info structure */
-		typedef struct hid_device_info {
+		struct hid_device_info {
 			/** Platform-specific device path */
 			char *path;
 			/** Device Vendor ID */
@@ -80,7 +80,7 @@ extern "C" {
 
 			/** Pointer to the next device */
 			struct hid_device_info *next;
-		} HID_DEVICE_INFO;
+		};
 
 
 		/** @brief Initialize the HIDAPI library.

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -46,7 +46,7 @@ extern "C" {
 		typedef struct hid_device_ hid_device; /**< opaque hidapi structure */
 
 		/** hidapi info structure */
-		struct hid_device_info {
+		typedef struct hid_device_info {
 			/** Platform-specific device path */
 			char *path;
 			/** Device Vendor ID */
@@ -80,7 +80,7 @@ extern "C" {
 
 			/** Pointer to the next device */
 			struct hid_device_info *next;
-		};
+		} HID_DEVICE_INFO;
 
 
 		/** @brief Initialize the HIDAPI library.

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -189,6 +189,15 @@ static void register_error(hid_device *dev, const char *op)
 }
 #endif
 
+static CFArrayRef get_array_property(IOHIDDeviceRef device, CFStringRef key) 
+{
+	CFTypeRef ref = IOHIDDeviceGetProperty(device, key);
+	if (ref != NULL && CFGetTypeID(ref) == CFArrayGetTypeID()) {
+		return (CFArrayRef)ref;
+	} else {
+		return NULL;
+	}
+}
 
 static int32_t get_int_property(IOHIDDeviceRef device, CFStringRef key)
 {
@@ -203,6 +212,11 @@ static int32_t get_int_property(IOHIDDeviceRef device, CFStringRef key)
 		}
 	}
 	return 0;
+}
+
+static CFArrayRef get_usage_pairs(IOHIDDeviceRef device) 
+{
+	return get_array_property(device, CFSTR(kIOHIDDeviceUsagePairsKey));
 }
 
 static unsigned short get_vendor_id(IOHIDDeviceRef device)
@@ -392,10 +406,121 @@ static void process_pending_events(void) {
 	} while(res != kCFRunLoopRunFinished && res != kCFRunLoopRunTimedOut);
 }
 
-struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+static HID_DEVICE_INFO *create_device_info_with_usage(IOHIDDeviceRef dev, int32_t usage_page, int32_t usage) 
 {
-	struct hid_device_info *root = NULL; /* return object */
-	struct hid_device_info *cur_dev = NULL;
+	unsigned short dev_vid;
+	unsigned short dev_pid;
+	int BUF_LEN = 256;
+	wchar_t buf[BUF_LEN];
+
+	HID_DEVICE_INFO *cur_dev;
+	io_object_t iokit_dev;
+	kern_return_t res;
+	io_string_t path;
+
+	if (dev == NULL) {
+		return NULL;
+	}
+
+	cur_dev = (HID_DEVICE_INFO *)calloc(1, sizeof(HID_DEVICE_INFO));
+
+	dev_vid = get_vendor_id(dev);
+	dev_pid = get_product_id(dev);
+
+	cur_dev->usage_page = usage_page;
+	cur_dev->usage = usage;
+
+	/* Fill out the record */
+	cur_dev->next = NULL;
+
+	/* Fill in the path (IOService plane) */
+	iokit_dev = hidapi_IOHIDDeviceGetService(dev);
+	res = IORegistryEntryGetPath(iokit_dev, kIOServicePlane, path);
+	if (res == KERN_SUCCESS)
+		cur_dev->path = strdup(path);
+	else
+		cur_dev->path = strdup("");
+
+	/* Serial Number */
+	get_serial_number(dev, buf, BUF_LEN);
+	cur_dev->serial_number = dup_wcs(buf);
+
+	/* Manufacturer and Product strings */
+	get_manufacturer_string(dev, buf, BUF_LEN);
+	cur_dev->manufacturer_string = dup_wcs(buf);
+	get_product_string(dev, buf, BUF_LEN);
+	cur_dev->product_string = dup_wcs(buf);
+
+	/* VID/PID */
+	cur_dev->vendor_id = dev_vid;
+	cur_dev->product_id = dev_pid;
+
+	/* Release Number */
+	cur_dev->release_number = get_int_property(dev, CFSTR(kIOHIDVersionNumberKey));
+
+	/* Interface Number (Unsupported on Mac)*/
+	cur_dev->interface_number = -1;
+
+	return cur_dev;
+}
+
+static HID_DEVICE_INFO *create_device_info(IOHIDDeviceRef device)
+{
+	HID_DEVICE_INFO *root = NULL;
+	CFArrayRef usage_pairs = get_usage_pairs(device);
+
+#ifdef DEBUG
+      // CFShow(usage_pairs);
+#endif
+
+	if (usage_pairs != NULL) {
+		HID_DEVICE_INFO *cur = NULL;
+		HID_DEVICE_INFO *next = NULL;
+		for (CFIndex i = 0; i < CFArrayGetCount(usage_pairs); i++) {
+			CFTypeRef dict = CFArrayGetValueAtIndex(usage_pairs, i);
+			if (CFGetTypeID(dict) != CFDictionaryGetTypeID()) {
+				continue;
+			}
+#ifdef DEBUG
+      // CFShow(dict);
+#endif
+			CFTypeRef usage_page_ref, usage_ref;
+			int32_t usage_page, usage;
+			
+			if (!CFDictionaryGetValueIfPresent((CFDictionaryRef)dict, CFSTR(kIOHIDDeviceUsagePageKey), &usage_page_ref) ||
+			    !CFDictionaryGetValueIfPresent((CFDictionaryRef)dict, CFSTR(kIOHIDDeviceUsageKey), &usage_ref) ||
+					CFGetTypeID(usage_page_ref) != CFNumberGetTypeID() ||
+					CFGetTypeID(usage_ref) != CFNumberGetTypeID() ||
+					!CFNumberGetValue((CFNumberRef)usage_page_ref, kCFNumberIntType, &usage_page) ||
+					!CFNumberGetValue((CFNumberRef)usage_ref, kCFNumberIntType, &usage)) {
+					continue;
+			}
+			next = create_device_info_with_usage(device, usage_page, usage);
+			if (cur == NULL) {
+				root = next;
+			}
+			else {
+				cur->next = next;
+			}
+			cur = next;
+		}
+	}
+
+	if (root == NULL) {
+		/* error when generating or parsing usage pairs */
+		int32_t usage_page = get_int_property(device, CFSTR(kIOHIDPrimaryUsagePageKey));
+		int32_t usage = get_int_property(device, CFSTR(kIOHIDPrimaryUsageKey));
+
+		root = create_device_info_with_usage(device, usage_page, usage);
+	}
+
+	return root;
+}
+
+HID_DEVICE_INFO  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+{
+	HID_DEVICE_INFO *root = NULL; /* return object */
+	HID_DEVICE_INFO *cur_dev = NULL;
 	CFIndex num_devices;
 	int i;
 
@@ -407,7 +532,30 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	process_pending_events();
 
 	/* Get a list of the Devices */
-	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
+	CFMutableDictionaryRef matching = NULL;
+	if (vendor_id != 0 || product_id != 0) {
+		matching = CFDictionaryCreateMutable(kCFAllocatorDefault, kIOHIDOptionsTypeNone, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+		if (vendor_id != 0) {
+			CFNumberRef v = CFNumberCreate(kCFAllocatorDefault, kCFNumberShortType, &vendor_id);
+			CFDictionarySetValue(matching, CFSTR(kIOHIDVendorIDKey), v);
+			CFRelease(v);
+		}
+
+		if (product_id != 0) {
+			CFNumberRef p = CFNumberCreate(kCFAllocatorDefault, kCFNumberShortType, &product_id);
+			CFDictionarySetValue(matching, CFSTR(kIOHIDProductIDKey), p);
+			CFRelease(p);
+		}
+#ifdef DEBUG
+		// CFShow(matching);
+#endif
+	}
+	IOHIDManagerSetDeviceMatching(hid_mgr, matching);
+	if (matching != NULL) {
+		CFRelease(matching);
+	}
+
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
 
 	/* Convert the list into a C array so we can iterate easily. */
@@ -417,81 +565,32 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 
 	/* Iterate over each device, making an entry for it. */
 	for (i = 0; i < num_devices; i++) {
-		unsigned short dev_vid;
-		unsigned short dev_pid;
-		#define BUF_LEN 256
-		wchar_t buf[BUF_LEN];
 
 		IOHIDDeviceRef dev = device_array[i];
+#ifdef DEBUG
+    // CFShow(dev);
+#endif
 
-        if (!dev) {
-            continue;
-        }
-		dev_vid = get_vendor_id(dev);
-		dev_pid = get_product_id(dev);
+		if (!dev) {
+				continue;
+		}
 
-		/* Check the VID/PID against the arguments */
-		if ((vendor_id == 0x0 || vendor_id == dev_vid) &&
-		    (product_id == 0x0 || product_id == dev_pid)) {
-			struct hid_device_info *tmp;
-			bool is_usb_hid; /* Is this an actual HID usb device */
-			io_object_t iokit_dev;
-			kern_return_t res;
-			io_string_t path;
+		HID_DEVICE_INFO *tmp = create_device_info(dev);
+		if (tmp == NULL) {
+			continue;
+		}
 
-			/* VID/PID match. Create the record. */
-			tmp = (struct hid_device_info*) calloc(1, sizeof(struct hid_device_info));
-			if (cur_dev) {
-				cur_dev->next = tmp;
-			}
-			else {
-				root = tmp;
-			}
-			cur_dev = tmp;
+		if (cur_dev) {
+			cur_dev->next = tmp;
+		}
+		else {
+			root = tmp;
+		}
+		cur_dev = tmp;
 
-			is_usb_hid = get_int_property(dev, CFSTR(kUSBInterfaceClass)) == kUSBHIDClass;
-
-			/* Get the Usage Page and Usage for this device. */
-			cur_dev->usage_page = get_int_property(dev, CFSTR(kIOHIDPrimaryUsagePageKey));
-			cur_dev->usage = get_int_property(dev, CFSTR(kIOHIDPrimaryUsageKey));
-
-			/* Fill out the record */
-			cur_dev->next = NULL;
-
-			/* Fill in the path (IOService plane) */
-			iokit_dev = hidapi_IOHIDDeviceGetService(dev);
-			res = IORegistryEntryGetPath(iokit_dev, kIOServicePlane, path);
-			if (res == KERN_SUCCESS)
-				cur_dev->path = strdup(path);
-			else
-				cur_dev->path = strdup("");
-
-			/* Serial Number */
-			get_serial_number(dev, buf, BUF_LEN);
-			cur_dev->serial_number = dup_wcs(buf);
-
-			/* Manufacturer and Product strings */
-			get_manufacturer_string(dev, buf, BUF_LEN);
-			cur_dev->manufacturer_string = dup_wcs(buf);
-			get_product_string(dev, buf, BUF_LEN);
-			cur_dev->product_string = dup_wcs(buf);
-
-			/* VID/PID */
-			cur_dev->vendor_id = dev_vid;
-			cur_dev->product_id = dev_pid;
-
-			/* Release Number */
-			cur_dev->release_number = get_int_property(dev, CFSTR(kIOHIDVersionNumberKey));
-
-			/* We can only retrieve the interface number for USB HID devices.
-			 * IOKit always seems to return 0 when querying a standard USB device
-			 * for its interface. */
-			if (is_usb_hid) {
-				/* Get the interface number */
-				cur_dev->interface_number = get_int_property(dev, CFSTR(kUSBInterfaceNumber));
-			} else {
-				cur_dev->interface_number = -1;
-			}
+		/* move the pointer to the tail of returnd list */
+		while (cur_dev->next != NULL) {
+		  cur_dev = cur_dev->next;	
 		}
 	}
 
@@ -501,12 +600,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	return root;
 }
 
-void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
+void  HID_API_EXPORT hid_free_enumeration(HID_DEVICE_INFO *devs)
 {
 	/* This function is identical to the Linux version. Platform independent. */
-	struct hid_device_info *d = devs;
+	HID_DEVICE_INFO *d = devs;
 	while (d) {
-		struct hid_device_info *next = d->next;
+		HID_DEVICE_INFO *next = d->next;
 		free(d->path);
 		free(d->serial_number);
 		free(d->manufacturer_string);
@@ -519,7 +618,7 @@ void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
 hid_device * HID_API_EXPORT hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
 {
 	/* This function is identical to the Linux version. Platform independent. */
-	struct hid_device_info *devs, *cur_dev;
+	HID_DEVICE_INFO *devs, *cur_dev;
 	const char *path_to_open = NULL;
 	hid_device * handle = NULL;
 

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -406,14 +406,14 @@ static void process_pending_events(void) {
 	} while(res != kCFRunLoopRunFinished && res != kCFRunLoopRunTimedOut);
 }
 
-static HID_DEVICE_INFO *create_device_info_with_usage(IOHIDDeviceRef dev, int32_t usage_page, int32_t usage) 
+static struct hid_device_info *create_device_info_with_usage(IOHIDDeviceRef dev, int32_t usage_page, int32_t usage) 
 {
 	unsigned short dev_vid;
 	unsigned short dev_pid;
 	int BUF_LEN = 256;
 	wchar_t buf[BUF_LEN];
 
-	HID_DEVICE_INFO *cur_dev;
+	struct hid_device_info *cur_dev;
 	io_object_t iokit_dev;
 	kern_return_t res;
 	io_string_t path;
@@ -422,7 +422,7 @@ static HID_DEVICE_INFO *create_device_info_with_usage(IOHIDDeviceRef dev, int32_
 		return NULL;
 	}
 
-	cur_dev = (HID_DEVICE_INFO *)calloc(1, sizeof(HID_DEVICE_INFO));
+	cur_dev = (struct hid_device_info *)calloc(1, sizeof(struct hid_device_info));
 
 	dev_vid = get_vendor_id(dev);
 	dev_pid = get_product_id(dev);
@@ -464,9 +464,9 @@ static HID_DEVICE_INFO *create_device_info_with_usage(IOHIDDeviceRef dev, int32_
 	return cur_dev;
 }
 
-static HID_DEVICE_INFO *create_device_info(IOHIDDeviceRef device)
+static struct hid_device_info *create_device_info(IOHIDDeviceRef device)
 {
-	HID_DEVICE_INFO *root = NULL;
+	struct hid_device_info *root = NULL;
 	CFArrayRef usage_pairs = get_usage_pairs(device);
 
 #ifdef DEBUG
@@ -474,8 +474,8 @@ static HID_DEVICE_INFO *create_device_info(IOHIDDeviceRef device)
 #endif
 
 	if (usage_pairs != NULL) {
-		HID_DEVICE_INFO *cur = NULL;
-		HID_DEVICE_INFO *next = NULL;
+		struct hid_device_info *cur = NULL;
+		struct hid_device_info *next = NULL;
 		for (CFIndex i = 0; i < CFArrayGetCount(usage_pairs); i++) {
 			CFTypeRef dict = CFArrayGetValueAtIndex(usage_pairs, i);
 			if (CFGetTypeID(dict) != CFDictionaryGetTypeID()) {
@@ -517,10 +517,10 @@ static HID_DEVICE_INFO *create_device_info(IOHIDDeviceRef device)
 	return root;
 }
 
-HID_DEVICE_INFO  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
 {
-	HID_DEVICE_INFO *root = NULL; /* return object */
-	HID_DEVICE_INFO *cur_dev = NULL;
+	struct hid_device_info *root = NULL; /* return object */
+	struct hid_device_info *cur_dev = NULL;
 	CFIndex num_devices;
 	int i;
 
@@ -575,7 +575,7 @@ HID_DEVICE_INFO  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigne
 				continue;
 		}
 
-		HID_DEVICE_INFO *tmp = create_device_info(dev);
+		struct hid_device_info *tmp = create_device_info(dev);
 		if (tmp == NULL) {
 			continue;
 		}
@@ -600,12 +600,12 @@ HID_DEVICE_INFO  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigne
 	return root;
 }
 
-void  HID_API_EXPORT hid_free_enumeration(HID_DEVICE_INFO *devs)
+void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
 {
 	/* This function is identical to the Linux version. Platform independent. */
-	HID_DEVICE_INFO *d = devs;
+	struct hid_device_info *d = devs;
 	while (d) {
-		HID_DEVICE_INFO *next = d->next;
+		struct hid_device_info *next = d->next;
 		free(d->path);
 		free(d->serial_number);
 		free(d->manufacturer_string);
@@ -618,7 +618,7 @@ void  HID_API_EXPORT hid_free_enumeration(HID_DEVICE_INFO *devs)
 hid_device * HID_API_EXPORT hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
 {
 	/* This function is identical to the Linux version. Platform independent. */
-	HID_DEVICE_INFO *devs, *cur_dev;
+	struct hid_device_info *devs, *cur_dev;
 	const char *path_to_open = NULL;
 	hid_device * handle = NULL;
 


### PR DESCRIPTION
This change supports one device has multiple usage/usage-page pairs on MacOS, which is already supported on Windows.