### PR TITLE
Fixed tag name for hidapi releases

### DIFF
--- a/dist/hidapi.podspec
+++ b/dist/hidapi.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.platform     = :osx
   spec.osx.deployment_target = "10.7"
 
-  spec.source       = { :git => "https://github.com/libusb/hidapi.git", :tag => "#{spec.version}" }
+  spec.source       = { :git => "https://github.com/libusb/hidapi.git", :tag => "hidapi-#{spec.version}" }
 
   spec.source_files = "mac/hid.c", "hidapi/hidapi.h"
 


### PR DESCRIPTION
Unfortunately I made a mistake in podspec. For some reason validation (`pod spec lint`) worked, but I tried to use podspec using `pod 'hidapi', :podspec => 'https://github.com/libusb/hidapi/raw/master/dist/hidapi.podspec'` without success, because of tag names.

This PR has to fix the issue