### PR TITLE
support multiple usage/usage-pages on macOS, update of @fengj2006 PR#65 

### DIFF
--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -55,6 +55,7 @@ int main(int argc, char* argv[])
 		printf("  Product:      %ls\n", cur_dev->product_string);
 		printf("  Release:      %hx\n", cur_dev->release_number);
 		printf("  Interface:    %d\n",  cur_dev->interface_number);
+		printf("  Usage (page): 0x%hx (0x%hx)\n", cur_dev->usage, cur_dev->usage_page);
 		printf("\n");
 		cur_dev = cur_dev->next;
 	}

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -792,11 +792,11 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 	io_registry_entry_t entry = MACH_PORT_NULL;
 	IOReturn ret = kIOReturnInvalid;
 
-	dev = new_hid_device();
-
 	/* Set up the HID Manager if it hasn't been done */
 	if (hid_init() < 0)
-		return NULL;
+		goto return_error;
+
+	dev = new_hid_device();
 
 	/* Get the IORegistry entry for the given path */
 	entry = IORegistryEntryFromPath(kIOMasterPortDefault, path);


### PR DESCRIPTION
I think this includes all the requested changes, on top of the work done by @fengj2006 on https://github.com/libusb/hidapi/pull/65

You can now see all the different usages as different "devices" in `hid_enumerate()`.  When running `hidtest` you see them too.  On a Macbook with internal keyboard/trackpad, there are many:

```
% ./hidtest | grep -E "(Product|Usage)"
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0x3 (0xff00)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0xd (0xff00)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0x2 (0x1)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0x1 (0x1)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0x5 (0xd)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0xc (0xff00)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0x6 (0x1)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0x1 (0xc)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0x6 (0xff00)
  Product:      Apple Internal Keyboard / Trackpad
  Usage (page): 0xb (0xff00)
```

Additionally, I've verified that an Arduino "RawHID" device with two usages shows up as two devices to hidapi
 
(the device is a $9 Trinket M0 running TinyUSB pretending to like Teensy in RawHID mode)  You can see this here: https://github.com/todbot/hidapitester/tree/master/tinyusb_teensyrawhid_multiusage

 