### PR TITLE
Windows Handle GetOverlappedResult blocking on read/write fix (#128)

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -180,7 +180,7 @@ static void register_error(hid_device *dev, const char *op)
 {
 	WCHAR *ptr, *msg;
 
-	(void)op; //Unrefd param
+	(void)op; // unreferenced  param
 	FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
 		FORMAT_MESSAGE_FROM_SYSTEM |
 		FORMAT_MESSAGE_IGNORE_INSERTS,

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -248,24 +248,6 @@ static HANDLE open_device(const char *path, BOOL open_rw)
 		FILE_FLAG_OVERLAPPED,/*FILE_ATTRIBUTE_NORMAL,*/
 		0);
 
-	/* Seen a problem with an application (AccuWeather) causing
-		   a sharing violation and the device can not be opened for R+W,SHARE_READ
-		   The app must open it for share R+W so we must also open it for share R+W
-		   i.e. we can't be the 2nd CreateFile as say "Only allow others to SHARE_READ"
-		   So as a last resort open the file with SHARE_READ/WRITE, this does mean
-		   that two people can have the device open for write, but no other option
-		   if a rogue application is doing something silly. */
-	if (handle == INVALID_HANDLE_VALUE)
-		{
-			handle = CreateFileA(path,
-								GENERIC_WRITE |GENERIC_READ,
-								FILE_SHARE_READ|FILE_SHARE_WRITE, /*share mode*/
-								NULL,
-								OPEN_EXISTING,
-								FILE_FLAG_OVERLAPPED,/*FILE_ATTRIBUTE_NORMAL,*/
-								0);
-		}
-
 	return handle;
 }
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -726,7 +726,8 @@ int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char 
 			}
 			overlapped = TRUE;	   
 		}																		   
-	}else {
+	}
+	else {
 		overlapped = TRUE;	
 	}
 


### PR DESCRIPTION
- Implemented solution from issue signal11/hidapi#88
- Allows read/write frames up to 1000 per second