### PR TITLE
Fix build when targeting Android 7 or later

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -51,7 +51,7 @@
 
 #include "hidapi.h"
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && __ANDROID_API__ < __ANDROID_API_N__
 
 /* Barrier implementation because Android/Bionic don't have pthread_barrier.
    This implementation came from Brent Priddy and was posted on


### PR DESCRIPTION
Support for pthread_barrier was introduced in Android 7, so trying to build a custom implementation of that clashes with the system headers.