### PR TITLE
Fix: Hanging inside hid_close()

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -844,8 +844,10 @@ static void *read_thread(void *param)
 	   if no transfers are pending, but that's OK. */
 	libusb_cancel_transfer(dev->transfer);
 
-	while (!dev->cancelled)
+	while (!dev->cancelled) {
+		libusb_cancel_transfer(dev->transfer);
 		libusb_handle_events_completed(usb_context, &dev->cancelled);
+	}
 
 	/* Now that the read thread is stopping, Wake any threads which are
 	   waiting on data (in hid_read_timeout()). Do this under a mutex to


### PR DESCRIPTION
#142 

Function hid_close() waits exit of read_thread().
Thread read_thread() at the end sets 
     libusb_cancel_transfer(dev->transfer);
and goes to 
     while (!dev->cancelled)
               libusb_handle_events_completed(usb_context, &dev->cancelled);

where libusb calls function read_callback() that should set dev->cancelled to 1.

The problem is: in normal transfer->status should be LIBUSB_TRANSFER_CANCELLED,
but time to time it is LIBUSB_TRANSFER_COMPLETED, I do not know why.
in that case dev->cancelled never set to 1 and we hang in a while().
