### PR TITLE
Move local variable declaration to the beginning of the function

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -828,8 +828,8 @@ int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *dev, unsigned
 
 int HID_API_EXPORT HID_API_CALL hid_get_input_report(hid_device *dev, unsigned char *data, size_t length)
 {
-#if 0
 	BOOL res;
+#if 0
 	res = HidD_GetInputReport(dev->device_handle, data, length);
 	if (!res) {
 		register_error(dev, "HidD_GetInputReport");
@@ -842,7 +842,7 @@ int HID_API_EXPORT HID_API_CALL hid_get_input_report(hid_device *dev, unsigned c
 	OVERLAPPED ol;
 	memset(&ol, 0, sizeof(ol));
 
-	BOOL res = DeviceIoControl(dev->device_handle,
+	res = DeviceIoControl(dev->device_handle,
 		IOCTL_HID_GET_INPUT_REPORT,
 		data, length,
 		data, length,


### PR DESCRIPTION
Older versions of MSVC (for example when using Visual Studio 10) don't yet support variable declaration in the middle of blocks:

```
hidapi\windows\hid.c(845) : error C2275: 'BOOL' : illegal use of this type as an expression
        C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\include\windef.h(153) : see declaration of 'BOOL'
```

Move the declaration of `res` to the beginning of the function.  Like in `hid_get_feature_report`, only `res` is moved, essentially ignoring the `#if 0` block (or assuming it will never be enabled).

---

Fixes: 083223e77952 ("Added support for Get Input Report")
Downstream issue: trezor/cython-hidapi#81 ("WIP: Fix build issues on AppVeyor")