### PR TITLE
Fix compilation warning in pedantic mode on macOS

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -827,7 +827,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 		/* Create the Run Loop Mode for this device.
 		   printing the reference seems to work. */
-		sprintf(str, "HIDAPI_%p", dev->device_handle);
+		sprintf(str, "HIDAPI_%p", (void*) dev->device_handle);
 		dev->run_loop_mode =
 			CFStringCreateWithCString(NULL, str, kCFStringEncodingASCII);
 


### PR DESCRIPTION
The compiler provided the following warning message:
```
hid.c:830:29: warning: format specifies type 'void *' but the argument has type 'IOHIDDeviceRef' (aka 'struct __IOHIDDevice *') [-Wformat-pedantic]
                sprintf(str, "HIDAPI_%p", dev->device_handle);
                                     ~~   ^~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
```