### PR TITLE
testgui: ensure $EXEPATH is a directory

### DIFF
--- a/testgui/copy_to_bundle.sh
+++ b/testgui/copy_to_bundle.sh
@@ -77,6 +77,7 @@ function copydeps {
 }
 
 rm -f $EXEPATH/*
+mkdir -p $EXEPATH
 
 # Copy the binary into the bundle. Use ../libtool to do this if it's
 # available because if $EXE_NAME was built with autotools, it will be


### PR DESCRIPTION
Otherwise hidapi-testgui will be put at TestGUI.app/Contents/MacOS which
results in a malformed .app structure.

The following build combinations have been tested:
* 'make -f Makefile-manual' with libtool
* 'make -f Makefile-manual' without libtool
* './configure --enable-testgui && make'

Fixes #151