### PR TITLE
Add hid_get_path to API resolves #163

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -417,6 +417,16 @@ extern "C" {
 		*/
 		int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen);
 
+		/** @brief Get the Path String from a HID device.
+
+			@ingroup API
+			@param dev A device handle returned from hid_open().
+
+			@returns
+				This function returns a pointer to path string or NULL on error.
+		*/
+		HID_API_EXPORT_CALL const char *hid_get_path(hid_device *dev);
+
 		/** @brief Get a string describing the last error which occurred.
 
 			Whether a function sets the last error is noted in its

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -76,6 +76,9 @@ int main(int argc, char* argv[])
  		return 1;
 	}
 
+	// Read the Path to the Device
+	printf("Path: \"%s\"\n", hid_get_path(handle));
+
 	// Read the Manufacturer String
 	wstr[0] = 0x0000;
 	res = hid_get_manufacturer_string(handle, wstr, MAX_STR);

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -917,10 +917,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 						}
 						good_open = 1;
 						/* Save path */
-						size_t len = strlen(path);
-						dev->path = (char *) calloc(len+1, sizeof(char));
-						strncpy(dev->path, path, len+1);
-						dev->path[len] = '\0';
+						dev->path = strdup(path);
 
 #ifdef DETACH_KERNEL_DRIVER
 						/* Detach the kernel driver, but only if the

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -664,10 +664,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		register_device_error(dev, NULL);
 
 		/* Save path */
-		size_t len = strlen(path);
-		dev->path = (char *) calloc(len+1, sizeof(char));
-		strncpy(dev->path, path, len+1);
-		dev->path[len] = '\0';
+		dev->path = strdup(path);
 
 		/* Get the report descriptor */
 		int res, desc_size = 0;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -828,10 +828,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		char str[32];
 
 		/* Save path */
-		size_t len = strlen(path);
-		dev->path = (char *) calloc(len+1, sizeof(char));
-		strncpy(dev->path, path, len+1);
-		dev->path[len] = '\0';
+		dev->path = strdup(path);
 
 		/* Create the buffers for receiving data */
 		dev->max_input_report_len = (CFIndex) get_max_report_length(dev->device_handle);

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -598,10 +598,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 	}
 
 	/* Save path */
-	size_t len = strlen(path);
-	dev->path = (char *) calloc(len+1, sizeof(char));
-	strncpy(dev->path, path, len+1);
-	dev->path[len] = '\0';
+	dev->path = strdup(path);
 
 	/* Set the Input Report buffer size to 64 reports. */
 	res = HidD_SetNumInputBuffers(dev->device_handle, 64);


### PR DESCRIPTION
This resolves the ability to get the device path from hid_device pointer issue in #163 

Add a new hid_get_path function to the API.  This adds a new path member
to the opaque structure of each hid implementation.  The path is
dynamically allocated and populated in the respective hid_open_path
functions.  The function returns a const char pointer to this path
string.

- Add path string to each hid_device_ structure in hid.c files
- Add hid_get_path function to hidapi.h and hid.c files
- Add init and free code for dev->path to hid.c files
- Allocate and populate dev->path in hid_open_path in hid.c files
- Add example of hid_get_path usage in test.c