### PR TITLE
Don't leak device handle in macOS 10.10 or newer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ case $host in
 	backend="mac"
 	os="darwin"
 	threads="pthreads"
-	LIBS="${LIBS} -framework IOKit -framework CoreFoundation"
+	LIBS="${LIBS} -framework IOKit -framework CoreFoundation -framework AppKit"
 	;;
 *-freebsd*)
 	AC_MSG_RESULT([ (FreeBSD back-end)])

--- a/mac/Makefile-manual
+++ b/mac/Makefile-manual
@@ -12,7 +12,7 @@ CC=gcc
 COBJS=hid.o ../hidtest/test.o
 OBJS=$(COBJS)
 CFLAGS+=-I../hidapi -Wall -g -c 
-LIBS=-framework IOKit -framework CoreFoundation
+LIBS=-framework IOKit -framework CoreFoundation -framework AppKit
 
 
 hidtest: $(OBJS)

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -183,7 +183,7 @@ static void free_hid_device(hid_device *dev)
 }
 
 static	IOHIDManagerRef hid_mgr = 0x0;
-static	int is_macos_10_11_or_greater = 0;
+static	int is_macos_10_10_or_greater = 0;
 
 
 #if 0
@@ -384,7 +384,7 @@ static int init_hid_manager(void)
 int HID_API_EXPORT hid_init(void)
 {
 	if (!hid_mgr) {
-		is_macos_10_11_or_greater = (NSAppKitVersionNumber >= 1404); /* NSAppKitVersionNumber10_11 */
+		is_macos_10_10_or_greater = (NSAppKitVersionNumber >= 1343); /* NSAppKitVersionNumber10_10 */
 		return init_hid_manager();
 	}
 
@@ -1101,7 +1101,7 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 	/* Disconnect the report callback before close.
 	   See comment below.
 	*/
-	if (is_macos_10_11_or_greater || !dev->disconnected) {
+	if (is_macos_10_10_or_greater || !dev->disconnected) {
 		IOHIDDeviceRegisterInputReportCallback(
 			dev->device_handle, dev->input_report_buf, dev->max_input_report_len,
 			NULL, dev);
@@ -1132,7 +1132,7 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 	   crash happenes if IOHIDDeviceClose() is not called.
 	   Not leaking a resource in all tested environments.
 	*/
-	if (is_macos_10_11_or_greater || !dev->disconnected) {
+	if (is_macos_10_10_or_greater || !dev->disconnected) {
 		IOHIDDeviceClose(dev->device_handle, kIOHIDOptionsTypeSeizeDevice);
 	}
 

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -917,7 +917,7 @@ static int get_report(hid_device *dev, IOHIDReportType type, unsigned char *data
 	                           report, &report_length);
 
 	if (res == kIOReturnSuccess) {
-		if (report_id == 0x0) { // 0 report number still present at the beginning
+		if (report_id == 0x0) { /* 0 report number still present at the beginning */
 			report_length++;
 		}
 		return report_length;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -36,6 +36,9 @@
 
 #include "hidapi.h"
 
+/* As defined in AppKit.h, but we don't need the entire AppKit for a single constant. */
+extern const double NSAppKitVersionNumber;
+
 /* Barrier implementation because Mac OSX doesn't have pthread_barrier.
    It also doesn't have clock_gettime(). So much for POSIX and SUSv2.
    This implementation came from Brent Priddy and was posted on
@@ -180,6 +183,7 @@ static void free_hid_device(hid_device *dev)
 }
 
 static	IOHIDManagerRef hid_mgr = 0x0;
+static	int is_macos_10_11_or_greater = 0;
 
 
 #if 0
@@ -380,6 +384,7 @@ static int init_hid_manager(void)
 int HID_API_EXPORT hid_init(void)
 {
 	if (!hid_mgr) {
+		is_macos_10_11_or_greater = (NSAppKitVersionNumber >= 1404); /* NSAppKitVersionNumber10_11 */
 		return init_hid_manager();
 	}
 
@@ -1093,8 +1098,10 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 	if (!dev)
 		return;
 
-	/* Disconnect the report callback before close. */
-	if (!dev->disconnected) {
+	/* Disconnect the report callback before close.
+	   See comment below.
+	*/
+	if (is_macos_10_11_or_greater || !dev->disconnected) {
 		IOHIDDeviceRegisterInputReportCallback(
 			dev->device_handle, dev->input_report_buf, dev->max_input_report_len,
 			NULL, dev);
@@ -1118,8 +1125,14 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 	/* Close the OS handle to the device, but only if it's not
 	   been unplugged. If it's been unplugged, then calling
-	   IOHIDDeviceClose() will crash. */
-	if (!dev->disconnected) {
+	   IOHIDDeviceClose() will crash.
+
+	   UPD: The crash part was true in/until some version of macOS.
+	   Starting with macOS 10.15, there is an opposite effect in some environments:
+	   crash happenes if IOHIDDeviceClose() is not called.
+	   Not leaking a resource in all tested environments.
+	*/
+	if (is_macos_10_11_or_greater || !dev->disconnected) {
 		IOHIDDeviceClose(dev->device_handle, kIOHIDOptionsTypeSeizeDevice);
 	}
 

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -465,7 +465,7 @@ static struct hid_device_info *create_device_info_with_usage(IOHIDDeviceRef dev,
 	/* We can only retrieve the interface number for USB HID devices.
 	 * IOKit always seems to return 0 when querying a standard USB device
 	 * for its interface. */
-	bool is_usb_hid = get_int_property(dev, CFSTR(kUSBInterfaceClass)) == kUSBHIDClass;
+	int is_usb_hid = get_int_property(dev, CFSTR(kUSBInterfaceClass)) == kUSBHIDClass;
 	if (is_usb_hid) {
 		/* Get the interface number */
 		cur_dev->interface_number = get_int_property(dev, CFSTR(kUSBInterfaceNumber));


### PR DESCRIPTION
In one of the early versions of macOS, when you try to close the device
with IOHIDDeviceClose() that is being physically disconnected.
Starting with some version of macOS, this crash bug was fixed,
and starting with macSO 10.15 the opposite effect took place:
in some environments crash happens if IOHIDDeviceClose() is _not_ called.

This patch is to keep a workaround for old versions of macOS,
and don't have a leak in new/tested environments.

Fixes: #144.