### PR TITLE
MSVC: crash bugfix when trying to open device without a serial number

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -548,7 +548,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open(unsigned short vendor_id, unsi
 		if (cur_dev->vendor_id == vendor_id &&
 		    cur_dev->product_id == product_id) {
 			if (serial_number) {
-				if (wcscmp(serial_number, cur_dev->serial_number) == 0) {
+				if (cur_dev->serial_number && wcscmp(serial_number, cur_dev->serial_number) == 0) {
 					path_to_open = cur_dev->path;
 					break;
 				}


### PR DESCRIPTION
Currently trying to call `hid_open` on a device that doesn't have a serial number will result in a crash in the call to wcscmp here. Check that it's not null before calling wcscmp.