### PR TITLE
linux/hidraw: Don't consider open returning 0 as an error

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -668,7 +668,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 	dev->device_handle = open(path, O_RDWR);
 
 	/* If we have a good handle, return it. */
-	if (dev->device_handle > 0) {
+	if (dev->device_handle >= 0) {
 		/* Set device error to none */
 		register_device_error(dev, NULL);
 


### PR DESCRIPTION
The open systcall is allowed to return 0 as a valid file descriptor,
and considering it an error breaks environments where unnecessary
fds are closed before executing untrusted processes.

Fixes: #199

Signed-off-by: Marc Zyngier <maz@kernel.org>