### PR TITLE
Read podspec version from VERSION file

### DIFF
--- a/dist/hidapi.podspec
+++ b/dist/hidapi.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "hidapi"
-  spec.version      = "<fill me up from VERSION file, before submit>"
+  spec.version      = File.read('../VERSION')
   spec.summary      = "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows."
 
   spec.description  = <<-DESC


### PR DESCRIPTION
I've successfully published `hidapi.podspec` for v0.10.0 using this file. With this change we don't have to edit podspec file to release next versions of hidapi