### PR TITLE
More specific pointer cast to work in all build environments

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -192,7 +192,7 @@ static void register_error(hid_device *dev, const char *op)
 		NULL,
 		GetLastError(),
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-		(LPVOID)&msg, 0/*sz*/,
+		(LPWSTR)&msg, 0/*sz*/,
 		NULL);
 	
 	/* Get rid of the CR and LF that FormatMessage() sticks at the


### PR DESCRIPTION
Type cast that works with more configurations of Visual Studio.  Enables building out of the box with the standard vrpn.dsw file from github.com/vrpn/vrpn.

The more-specific cast works with both the CMake version and the stock solution file.  The more general LPVOID cast worked with CMake but failed with the stock file.