### PR TITLE
hidapi.h: fix API prototype for gcc flag -Wstrict-prototypes

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -478,7 +478,7 @@ extern "C" {
 			@returns
 				Pointer to statically allocated struct, that contains version.
 		*/
-		HID_API_EXPORT const  struct hid_api_version* HID_API_CALL hid_version();
+		HID_API_EXPORT const  struct hid_api_version* HID_API_CALL hid_version(void);
 
 
 		/** @brief Get a runtime version string of the library.
@@ -488,7 +488,7 @@ extern "C" {
 			@returns
 				Pointer to statically allocated string, that contains version string.
 		*/
-		HID_API_EXPORT const char* HID_API_CALL hid_version_str();
+		HID_API_EXPORT const char* HID_API_CALL hid_version_str(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
With gcc 10.2.0 and compile flag '-Wstrict-prototypes' the new
APIs in hidapi.h trigger a compile warning:

../hidapi/hidapi.h:481:32: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  481 |   HID_API_EXPORT const  struct hid_api_version* HID_API_CALL hid_version();
      |                                ^~~~~~~~~~~~~~~
../hidapi/hidapi.h:491:3: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  491 |   HID_API_EXPORT const char* HID_API_CALL hid_version_str();
      |   ^~~~~~~~~~~~~~

To replicate:
	./bootstrap
	CFLAG=-Wstrict-prototypes ./configure
	make

This is an issue for other projects, like OpenOCD, that use hidapi
and compile by default with '-Wstrict-prototypes -Werror'; the
warning above causes compile error while including hidapi.h.

Fix the prototypes by adding 'void' in the empty parameter list.

Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>