### PR TITLE
macOS: check if IOHIDManagerCopyDevices returned a NULL

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -583,6 +583,9 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	}
 
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
+	if (device_set == NULL) {
+		return NULL;
+	}
 
 	/* Convert the list into a C array so we can iterate easily. */
 	num_devices = CFSetGetCount(device_set);


### PR DESCRIPTION
Removes a possible cause for a segmentation fault observed in `CFSetGetCount` (see #208).

Note: completely untested (no access to a mac right now).