### PR TITLE
hid_get_input_report: Correct number of bytes_returned

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -937,11 +937,6 @@ int HID_API_EXPORT HID_API_CALL hid_get_input_report(hid_device *dev, unsigned c
 		return -1;
 	}
 
-	/* bytes_returned does not include the first byte which contains the
-	   report ID. The data buffer actually contains one more byte than
-	   bytes_returned. */
-	bytes_returned++;
-
 	return bytes_returned;
 #endif
 }


### PR DESCRIPTION
This fixes https://github.com/libusb/hidapi/issues/229