### PR TITLE
Added support for MSYS2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,13 @@ case $host in
 	threads="windows"
 	win_implementation="mingw"
 	;;
+*-msys*)
+	AC_MSG_RESULT([ (Windows back-end, using MSYS2)])
+	backend="windows"
+	os="windows"
+	threads="windows"
+	win_implementation="mingw"
+	;;
 *-cygwin*)
 	AC_MSG_RESULT([ (Windows back-end, using Cygwin)])
 	backend="windows"


### PR DESCRIPTION
Hello!

Build currently does not work under MSYS2, because it does not have it as an option for host OS in the configure script.
It is the same as MinGW, so I just copy-pasted that to a string which would be recognized under MSYS2.