### PR TITLE
Guard against zero length buffers in hid_write

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1047,7 +1047,6 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 	int skipped_report_id = 0;
 
 	if (!data || (length ==0)) {
-		errno = EINVAL;
 		return -1;
 	}
 

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1043,8 +1043,15 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t length)
 {
 	int res;
-	int report_number = data[0];
+	int report_number;
 	int skipped_report_id = 0;
+
+	if (!data || (length ==0)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	report_number = data[0];
 
 	if (report_number == 0x0) {
 		data++;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -963,6 +963,12 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 {
 	int bytes_written;
 
+	if (!data || (length == 0)) {
+		errno = EINVAL;
+		register_device_error(dev, strerror(errno));
+		return -1;
+	}
+
 	bytes_written = write(dev->device_handle, data, length);
 
 	register_device_error(dev, (bytes_written == -1)? strerror(errno): NULL);

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -898,7 +898,13 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
 	const unsigned char *data_to_send = data;
 	CFIndex length_to_send = length;
 	IOReturn res;
-	const unsigned char report_id = data[0];
+	unsigned char report_id;
+
+	if (!data || (length <= 0)) {
+		return -1;
+	}
+
+	report_id = data[0];
 
 	if (report_id == 0x0) {
 		/* Not using numbered Reports.

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -900,7 +900,7 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
 	IOReturn res;
 	unsigned char report_id;
 
-	if (!data || (length <= 0)) {
+	if (!data || (length == 0)) {
 		return -1;
 	}
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -660,7 +660,7 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 	unsigned char *buf;
 
 	if (!data || (length==0)) {
-		register_error(dev, "Zero length buffer")
+		register_error(dev, "Zero length buffer");
 		return function_result;
 	}
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -659,6 +659,11 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 
 	unsigned char *buf;
 
+	if (!data || (length==0)) {
+		register_error(dev, "Zero length buffer")
+		return function_result;
+	}
+
 	/* Make sure the right number of bytes are passed to WriteFile. Windows
 	   expects the number of bytes which are in the _longest_ report (plus
 	   one for the report number) bytes even if the data is a report


### PR DESCRIPTION
This is my proposed solution for avoiding a macOS panic in `set_report` when the user supplies a zero length buffer (indicated by either a NULL data or a length of 0 or less).

Looking back at the source, I see that `length` is of type `size_t` which my foggy brain remembers being unsigned so the test for `less than or equal to zero` should likely be `equal zero`. 

Fixes: #278 