### PR TITLE
win: hid_get_feature_report: Correct number of bytes_returned

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -881,11 +881,6 @@ int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *dev, unsigned
 		return -1;
 	}
 
-	/* bytes_returned does not include the first byte which contains the
-	   report ID. The data buffer actually contains one more byte than
-	   bytes_returned. */
-	bytes_returned++;
-
 	return bytes_returned;
 #endif
 }


### PR DESCRIPTION
This originally tested/confirmed by @mcuee.
Confirmed the expected behavior by Tim Roberts https://sourceforge.net/p/libusb/mailman/message/37303650/.