### PR TITLE
Update hid.c to fix MSYS2 MinGW-w64 compiler warning

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -63,17 +63,12 @@ extern "C" {
 
 #include <stdio.h>
 #include <stdlib.h>
-
+#include <string.h>
 
 #include "hidapi.h"
 
 #undef MIN
 #define MIN(x,y) ((x) < (y)? (x): (y))
-
-#ifdef _MSC_VER
-	/* Thanks Microsoft, but I know how to use strncpy(). */
-	#pragma warning(disable:4996)
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -330,8 +325,7 @@ static struct hid_device_info *hid_get_device_info(const char *path, HANDLE hand
 	if (path) {
 		size_t len = strlen(path);
 		dev->path = (char*)calloc(len + 1, sizeof(char));
-		strncpy(dev->path, path, len + 1);
-		dev->path[len] = '\0';
+		memcpy(dev->path, path, len + 1);
 	}
 	else
 		dev->path = NULL;


### PR DESCRIPTION
Fix issue #289 that there is a compiler warning when using MSYS2 MinGW-w64 compiler. 
```
[ 25%] Building C object src/windows/CMakeFiles/hidapi_winapi.dir/hid.c.obj
In function 'hid_get_device_info',
    inlined from 'hid_enumerate' at C:\work\hid\hidapi\windows\hid.c:517:34:
C:\work\hid\hidapi\windows\hid.c:333:3: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
  333 |   strncpy(dev->path, path, len + 1);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\work\hid\hidapi\windows\hid.c: In function 'hid_enumerate':
C:\work\hid\hidapi\windows\hid.c:331:16: note: length computed here
  331 |   size_t len = strlen(path);
      |                ^~~~~~~~~~~~

$ gcc -v
Using built-in specs.
COLLECT_GCC=C:\msys64\mingw64\bin\gcc.exe
COLLECT_LTO_WRAPPER=C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../gcc-10.3.0/configure --prefix=/mingw64 --with-local-prefix=/mingw64/local --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --with-native-system-header-dir=/mingw64/x86_64-w64-mingw32/include --libexecdir=/mingw64/lib --enable-bootstrap --enable-checking=release --with-arch=x86-64 --with-tune=generic --enable-languages=c,lto,c++,fortran,ada,objc,obj-c++,jit --enable-shared --enable-static --enable-libatomic --enable-threads=posix --enable-graphite --enable-fully-dynamic-string --enable-libstdcxx-filesystem-ts=yes --enable-libstdcxx-time=yes --disable-libstdcxx-pch --disable-libstdcxx-debug --enable-lto --enable-libgomp --disable-multilib --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-libiconv --with-system-zlib --with-gmp=/mingw64 --with-mpfr=/mingw64 --with-mpc=/mingw64 --with-isl=/mingw64 --with-pkgversion='Rev1, Built by MSYS2 project' --with-bugurl=https://github.com/msys2/MINGW-packages/issues --with-gnu-as --with-gnu-ld --with-boot-ldflags='-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc' 'LDFLAGS_FOR_TARGET=-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high' --enable-linker-plugin-flags='LDFLAGS=-static-libstdc++\ -static-libgcc\ -pipe\ -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high\ -Wl,--stack,12582912'
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 10.3.0 (Rev1, Built by MSYS2 project)
```

Signed-off-by: Xiaofan Chen xiaofanc@gmail.com