### PR TITLE
README: fix #include path to <hidapi/hidapi.h>

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ device spec. Writing data at random to your HID devices can break them.**
 #endif
 #include <stdio.h>
 #include <stdlib.h>
-#include "hidapi.h"
+#include <hidapi/hidapi.h>
 
 #define MAX_STR 255
 


### PR DESCRIPTION
The build system has always installed the hidapi.h header to
<hidapi/hidapi.h> relative to the installation prefix.