### PR TITLE
Windows: hid_get_feature/input_report return size fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,8 @@ Makefile
 stamp-h1
 libtool
 
+# macOS
 .DS_Store
+
+# Qt Creator
+CMakeLists.txt.user


### PR DESCRIPTION
- It appears when the numbered reports aren't used,
WinAPI returns size of the report excluding the data[0] which contains 0,
as an indication that numbered reports aren't used;
Explicity count that byte in the result.

Fixes: #328