### PR TITLE
Add <root>/libusb to includes for in-tree build

### DIFF
--- a/libusb/CMakeLists.txt
+++ b/libusb/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.6.3 FATAL_ERROR)
 
+list(APPEND HIDAPI_PUBLIC_HEADERS "hidapi_libusb.h")
+
 add_library(hidapi_libusb
     ${HIDAPI_PUBLIC_HEADERS}
     hid.c
-    hidapi_libusb.h
 )
 target_link_libraries(hidapi_libusb PUBLIC hidapi_include)
 
@@ -24,7 +25,7 @@ set_target_properties(hidapi_libusb
         OUTPUT_NAME "hidapi-libusb"
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
-        PUBLIC_HEADER "${HIDAPI_PUBLIC_HEADERS};hidapi_libusb.h"
+        PUBLIC_HEADER "${HIDAPI_PUBLIC_HEADERS}"
 )
 
 # compatibility with find_package()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,9 @@ else()
         set(HIDAPI_WITH_LIBUSB ON)
     endif()
     if(HIDAPI_WITH_LIBUSB)
+        target_include_directories(hidapi_include INTERFACE
+            "$<BUILD_INTERFACE:${PROJECT_ROOT}/libusb>"
+        )
         add_subdirectory("${PROJECT_ROOT}/libusb" libusb)
         list(APPEND EXPORT_COMPONENTS libusb)
         if(NOT EXPORT_ALIAS)


### PR DESCRIPTION
Otherwise it is impossible to `#include <hidapi_libusb.h>`,
when HIDAPI is added directly as a subdirectory of a CMake project.