### PR TITLE
Update 69-hid.rules

### DIFF
--- a/udev/69-hid.rules
+++ b/udev/69-hid.rules
@@ -7,7 +7,7 @@
 # those of your device.
 
 # HIDAPI/libusb
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="003f", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="003f", TAG+="uaccess"
 
 # If you are using the hidraw implementation (linux/hid.c), then do something
 # like the following, substituting the VID and PID with your device.


### PR DESCRIPTION
SUBSYSTEMS instead of SUBSYSTEM

I tested this on my Ubuntu 21.04 system, and when using the SUBSYSTEM keyword, I would not get a match. But when I switched to SUBSYSTEMS (prompted by a Stackoverflow comment) it immediately started working.