### PR TITLE
windows: add missing include for mingw32

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -33,6 +33,7 @@ typedef LONG NTSTATUS;
 #endif
 
 #ifdef __MINGW32__
+#include <devpropdef.h>
 #include <ntdef.h>
 #include <winbase.h>
 #endif


### PR DESCRIPTION
Seems to be introduced in https://github.com/libusb/hidapi/pull/309/

```
2021-11-10T00:31:43.7352733Z hid.c:164:83: error: unknown type name ‘DEVPROPKEY’
2021-11-10T00:31:43.7355003Z   typedef CONFIGRET(__stdcall* CM_Get_DevNode_PropertyW_)(DEVINST dnDevInst, CONST DEVPROPKEY* PropertyKey, DEVPROPTYPE* PropertyType, PBYTE PropertyBuffer, PULONG PropertyBufferSize, ULONG ulFlags);
```