### PR TITLE
HIDRAW hid_get_indexed_string implementation

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -39,6 +39,7 @@
 
 /* Linux */
 #include <linux/hidraw.h>
+#include <linux/hiddev.h>
 #include <linux/version.h>
 #include <linux/input.h>
 #include <libudev.h>

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1114,13 +1114,21 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 	return get_device_string(dev, DEVICE_STRING_SERIAL, string, maxlen);
 }
 
-int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
+int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device * dev, int string_index, wchar_t * string, size_t maxlen)
 {
-	(void)dev;
-	(void)string_index;
-	(void)string;
-	(void)maxlen;
-	return -1;
+
+	int res;
+	struct hiddev_string_descriptor str_desc;
+
+	str_desc.index = string_index;
+	res = ioctl(dev->device_handle, HIDIOCGSTRING, str_desc);
+	if (res < 0)
+		register_device_error_format(dev, "ioctl (GSTRING): %s", strerror(errno));
+	else {
+		mbstowcs(&string[0], str_desc.value, maxlen);
+	}
+
+	return res;
 }
 
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1115,9 +1115,8 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 	return get_device_string(dev, DEVICE_STRING_SERIAL, string, maxlen);
 }
 
-int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device * dev, int string_index, wchar_t * string, size_t maxlen)
+int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
 {
-
 	int res;
 	struct hiddev_string_descriptor str_desc;
 


### PR DESCRIPTION
This is untested code, coded offline without a physical Linux system.

The easiest way to test it, should be to read the first strings, where every HID device stores Manufacturer and ProductID.