### PR TITLE
Ported code from SetupApi to CfgMgr32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ if test "x$os" = xwindows; then
 	AC_DEFINE(OS_WINDOWS, 1, [Windows implementations])
 	AC_SUBST(OS_WINDOWS)
 	LDFLAGS="${LDFLAGS} -no-undefined"
-	LIBS="${LIBS} -lsetupapi"
+	LIBS="${LIBS}"
 fi
 
 if test "x$threads" = xpthreads; then

--- a/testgui/Makefile.mingw
+++ b/testgui/Makefile.mingw
@@ -14,7 +14,7 @@ COBJS=../windows/hid.o
 CPPOBJS=test.o
 OBJS=$(COBJS) $(CPPOBJS)
 CFLAGS=-I../hidapi -I../../hidapi-externals/fox/include -g -c
-LIBS= -mwindows -lsetupapi -L../../hidapi-externals/fox/lib -Wl,-Bstatic -lFOX-1.6 -Wl,-Bdynamic -lgdi32 -Wl,--enable-auto-import -static-libgcc -static-libstdc++ -lkernel32
+LIBS= -mwindows -L../../hidapi-externals/fox/lib -Wl,-Bstatic -lFOX-1.6 -Wl,-Bdynamic -lgdi32 -Wl,--enable-auto-import -static-libgcc -static-libstdc++ -lkernel32
 
 
 hidapi-testgui: $(OBJS)

--- a/testgui/testgui.vcproj
+++ b/testgui/testgui.vcproj
@@ -61,7 +61,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="setupapi.lib fox-1.6.lib"
+				AdditionalDependencies="fox-1.6.lib"
 				OutputFile="$(ProjectName).exe"
 				LinkIncremental="2"
 				AdditionalLibraryDirectories="..\hidapi\objfre_wxp_x86\i386;&quot;..\..\hidapi-externals\fox\lib&quot;"
@@ -139,7 +139,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="setupapi.lib fox-1.6.lib"
+				AdditionalDependencies="fox-1.6.lib"
 				OutputFile="$(ProjectName).exe"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories="..\hidapi\objfre_wxp_x86\i386;&quot;..\..\hidapi-externals\fox\lib&quot;"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(hidapi_winapi
 )
 target_link_libraries(hidapi_winapi
     PUBLIC hidapi_include
-    PRIVATE setupapi
 )
 
 set_target_properties(hidapi_winapi

--- a/windows/Makefile.mingw
+++ b/windows/Makefile.mingw
@@ -12,8 +12,8 @@ CC=gcc
 COBJS=hid.o ../hidtest/test.o
 OBJS=$(COBJS)
 CFLAGS=-I../hidapi -g -c
-LIBS= -lsetupapi
-DLL_LDFLAGS = -mwindows -lsetupapi
+LIBS=
+DLL_LDFLAGS = -mwindows
 
 hidtest: $(OBJS)
 	$(CC) -g $^ $(LIBS) -o hidtest

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -647,11 +647,14 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 		}
 
 		device_interface_list = (wchar_t*)calloc(len, sizeof(wchar_t));
+		if (device_interface_list == NULL) {
+			return NULL;
+		}
 		cr = CM_Get_Device_Interface_ListW(&interface_class_guid, NULL, device_interface_list, len, CM_GET_DEVICE_INTERFACE_LIST_PRESENT);
 	} while (cr == CR_BUFFER_SMALL);
 
 	if (cr != CR_SUCCESS) {
-		return NULL;
+		goto end_of_function;
 	}
 
 	/* Iterate over each device interface in the HID class, looking for the right one. */
@@ -697,6 +700,7 @@ cont_close:
 		CloseHandle(device_handle);
 	}
 
+end_of_function:
 	free(device_interface_list);
 
 	return root;

--- a/windows/hidapi.vcproj
+++ b/windows/hidapi.vcproj
@@ -61,7 +61,6 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="setupapi.lib"
 				LinkIncremental="2"
 				GenerateDebugInformation="true"
 				SubSystem="2"

--- a/windows/hidapi.vcxproj
+++ b/windows/hidapi.vcxproj
@@ -98,7 +98,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -117,7 +117,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -135,7 +135,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -157,7 +157,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
- Ported code from SetupApi to CfgMgr32. See: https://docs.microsoft.com/windows-hardware/drivers/install/porting-from-setupapi-to-cfgmgr32
- Use Unicode Windows API internally where possible. Windows operates natively in UTF-16 (WCHAR) so do we too.