### PR TITLE
Fix potential crash when libusb_detach_kernel_driver fails

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -923,7 +923,6 @@ static int hidapi_initialize_device(hid_device *dev, const struct libusb_interfa
 	if (libusb_kernel_driver_active(dev->device_handle, intf_desc->bInterfaceNumber) == 1) {
 		res = libusb_detach_kernel_driver(dev->device_handle, intf_desc->bInterfaceNumber);
 		if (res < 0) {
-			libusb_close(dev->device_handle);
 			LOG("Unable to detach Kernel Driver\n");
 			return 0;
 		}


### PR DESCRIPTION
In case if libusb_detach_kernel_driver fails inside hidapi_initialize_device
HIDAPI had tried to `libusb_close(dev->device_handle)` two times:
- right after `libusb_detach_kernel_driver`;
- outside of `hidapi_initialize_device` function;

The fix: `libusb_close` the device only once.
And since `hidapi_initialize_device` is not responsible for opening the device -
it is not responsible for closing it either.