### PR TITLE
Win32: hid_open_path hotfix

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -815,7 +815,10 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 end_of_function:
 	free(interface_path);
 	CloseHandle(device_handle);
-	HidD_FreePreparsedData(pp_data);
+
+	if (pp_data) {
+		HidD_FreePreparsedData(pp_data);
+	}
 
 	return dev;
 }


### PR DESCRIPTION
Don't pass invalid pointers to HidD_FreePreparsedData in hid_open_path

Fixes a segfault that happens when hid_open_path is called on a previously disconnected device.

This is a regression caused by:
b600727 - Win32: Fix memory leak in `free_hid_device` (#361)