### PR TITLE
Fix possible warnings on macOS

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -905,7 +905,7 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
 	                           data_to_send, length_to_send);
 
 	if (res == kIOReturnSuccess) {
-		return (int)length;
+		return (int) length;
 	}
 
 	return -1;
@@ -939,7 +939,7 @@ static int get_report(hid_device *dev, IOHIDReportType type, unsigned char *data
 		if (report_id == 0x0) { /* 0 report number still present at the beginning */
 			report_length++;
 		}
-		return (int)report_length;
+		return (int) report_length;
 	}
 
 	return -1;
@@ -961,7 +961,7 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 	dev->input_reports = rpt->next;
 	free(rpt->data);
 	free(rpt);
-	return (int)len;
+	return (int) len;
 }
 
 static int cond_wait(const hid_device *dev, pthread_cond_t *cond, pthread_mutex_t *mutex)

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -381,7 +381,7 @@ static struct hid_device_info *create_device_info_with_usage(IOHIDDeviceRef dev,
 	struct hid_device_info *cur_dev;
 	io_object_t iokit_dev;
 	kern_return_t res;
-	uint64_t entry_id;
+	uint64_t entry_id = 0;
 
 	if (dev == NULL) {
 		return NULL;
@@ -905,7 +905,7 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
 	                           data_to_send, length_to_send);
 
 	if (res == kIOReturnSuccess) {
-		return length;
+		return (int)length;
 	}
 
 	return -1;
@@ -939,7 +939,7 @@ static int get_report(hid_device *dev, IOHIDReportType type, unsigned char *data
 		if (report_id == 0x0) { /* 0 report number still present at the beginning */
 			report_length++;
 		}
-		return report_length;
+		return (int)report_length;
 	}
 
 	return -1;
@@ -961,7 +961,7 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 	dev->input_reports = rpt->next;
 	free(rpt->data);
 	free(rpt);
-	return len;
+	return (int)len;
 }
 
 static int cond_wait(const hid_device *dev, pthread_cond_t *cond, pthread_mutex_t *mutex)


### PR DESCRIPTION
Fixes the following warnings (or in our case errors when building with `-Werror`):

```
hid.c:420:45: error: variable 'entry_id' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
                        sprintf(cur_dev->path, "DevSrvsID:%llu", entry_id);
                                                                 ^~~~~~~~
In module 'Darwin' imported from hid.c:30:
/Applications/Xcode-13.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/secure/_stdio.h:47:56: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                                                       ^~~~~~~~~~~
hid.c:384:19: note: initialize the variable 'entry_id' to silence this warning
        uint64_t entry_id;
                         ^
                          = 0
hid.c:908:10: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
                return length;
                ~~~~~~ ^~~~~~
hid.c:942:10: error: implicit conversion loses integer precision: 'CFIndex' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
                return report_length;
                ~~~~~~ ^~~~~~~~~~~~~
hid.c:964:9: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
        return len;
        ~~~~~~ ^~~
```