### PR TITLE
Add Mac-specific API to get device location ID

### DIFF
--- a/mac/CMakeLists.txt
+++ b/mac/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
 
+list(APPEND HIDAPI_PUBLIC_HEADERS "hidapi_darwin.h")
+
 add_library(hidapi_darwin
     ${HIDAPI_PUBLIC_HEADERS}
     hid.c

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -34,7 +34,7 @@
 #include <unistd.h>
 #include <dlfcn.h>
 
-#include "hidapi.h"
+#include "hidapi_darwin.h"
 
 /* As defined in AppKit.h, but we don't need the entire AppKit for a single constant. */
 extern const double NSAppKitVersionNumber;
@@ -1186,6 +1186,17 @@ int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index
 	/* TODO: */
 
 	return 0;
+}
+
+int HID_API_EXPORT_CALL hid_darwin_get_location_id(hid_device *dev, uint32_t *location_id)
+{
+	int res = get_int_property(dev->device_handle, CFSTR(kIOHIDLocationIDKey));
+	if (res != 0) {
+		*location_id = (uint32_t) res;
+		return 0;
+	} else {
+		return -1;
+	}
 }
 
 

--- a/mac/hidapi_darwin.h
+++ b/mac/hidapi_darwin.h
@@ -1,0 +1,50 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ libusb/hidapi Team
+
+ Copyright 2022, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        https://github.com/libusb/hidapi .
+********************************************************/
+
+/** @file
+ * @defgroup API hidapi API
+ */
+
+#ifndef HIDAPI_DARWIN_H__
+#define HIDAPI_DARWIN_H__
+
+#include <stdint.h>
+
+#include "hidapi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+		/** @brief Get the location ID for a HID device.
+
+			@ingroup API
+			@param dev A device handle returned from hid_open().
+			@param location_id The device's location ID on return.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_darwin_get_location_id(hid_device *dev, uint32_t *location_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
As discussed in https://github.com/libusb/hidapi/discussions/252#discussioncomment-2089707.

Not sure if there’s a simpler way to do this, but as I need the location ID during enumeration it seems I first need to create a `IOHIDDeviceRef` from the path in order to get the location ID.