### PR TITLE
libusb: Fix double free of buffer pointer in hid_close()

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1408,6 +1408,7 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 	/* Clean up the Transfer objects allocated in read_thread(). */
 	free(dev->transfer->buffer);
+	dev->transfer->buffer = NULL;
 	libusb_free_transfer(dev->transfer);
 
 	/* release the interface */


### PR DESCRIPTION
In hid_close() buffer pointer is freed and next to that the
libusb_free_transfer function is called which checks for if
the LIBUSB_TRANSFER_FREE_BUFFER flag is set and the buffer
pointer is not NULL. when this condition evaluates true, it
tries to free memory for a buffer which is already free and
a crash occurs.
Make buffer pointer NULL, once it is freed.