### PR TITLE
Fix find_package(hidapi) warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,7 +150,7 @@ if(HIDAPI_INSTALL_TARGETS)
     include(CMakePackageConfigHelpers)
     set(EXPORT_DENERATED_LOCATION "${CMAKE_BINARY_DIR}/export_generated")
     set(EXPORT_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hidapi")
-    write_basic_package_version_file("${EXPORT_DENERATED_LOCATION}/hidapi-config-version.cmake"
+    write_basic_package_version_file("${EXPORT_DENERATED_LOCATION}/libhidapi-version.cmake"
         COMPATIBILITY SameMajorVersion
     )
     configure_package_config_file("cmake/hidapi-config.cmake.in" "${EXPORT_DENERATED_LOCATION}/hidapi-config.cmake"
@@ -161,9 +161,10 @@ if(HIDAPI_INSTALL_TARGETS)
     install(EXPORT hidapi
         DESTINATION "${EXPORT_DESTINATION}"
         NAMESPACE hidapi::
+        FILE "libhidapi.cmake"
     )
     install(FILES
-            "${EXPORT_DENERATED_LOCATION}/hidapi-config-version.cmake"
+            "${EXPORT_DENERATED_LOCATION}/libhidapi-version.cmake"
             "${EXPORT_DENERATED_LOCATION}/hidapi-config.cmake"
         DESTINATION "${EXPORT_DESTINATION}"
     )

--- a/src/cmake/hidapi-config.cmake.in
+++ b/src/cmake/hidapi-config.cmake.in
@@ -23,7 +23,7 @@ if(HIDAPI_NEED_EXPORT_LIBUSB OR HIDAPI_NEED_EXPORT_LIBUDEV)
   if(CMAKE_VERSION VERSION_LESS 3.6.3)
     message(FATAL_ERROR "This file relies on consumers using CMake 3.6.3 or greater.")
   endif()
-  include(FindPkgConfig)
+  find_package(PkgConfig)
   if(HIDAPI_NEED_EXPORT_LIBUSB)
     pkg_check_modules(libusb REQUIRED IMPORTED_TARGET libusb-1.0>=1.0.9)
   endif()
@@ -32,7 +32,7 @@ if(HIDAPI_NEED_EXPORT_LIBUSB OR HIDAPI_NEED_EXPORT_LIBUDEV)
   endif()
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/hidapi.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/libhidapi.cmake")
 
 set(hidapi_FOUND TRUE)
 


### PR DESCRIPTION
- FindPkgConfig.cmake warns it is not called by find_package;
- CMake package `config` file and `exports` file names should not match,
otherwise it gets included recursively by GLOB expression;