### PR TITLE
Don't use deprecated kIOMasterPortDefault

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -790,12 +790,12 @@ static io_registry_entry_t hid_open_service_registry_from_path(const char *path)
 		char *endptr;
 		uint64_t entry_id = strtoull(path + 10, &endptr, 10);
 		if (*endptr == '\0') {
-			return IOServiceGetMatchingService(kIOMasterPortDefault, IORegistryEntryIDMatching(entry_id));
+			return IOServiceGetMatchingService(NULL, IORegistryEntryIDMatching(entry_id));
 		}
 	}
 	else {
 		/* Fallback to older format of the path */
-		return IORegistryEntryFromPath(kIOMasterPortDefault, path);
+		return IORegistryEntryFromPath(NULL, path);
 	}
 
 	return MACH_PORT_NULL;


### PR DESCRIPTION
`kIOMasterPortDefault` is deprecated since macOS 12.0.
One alternative is to use named constant `kIOMainPortDefault` which is not available before macOS 12.0.

Both named constants are just an alias for `NULL`, so it is simpler to use it directly instead.

Fixes: #377