### PR TITLE
Fix: memory write out of bounds. (windows)

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1081,7 +1081,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_manufacturer_string(hid_device *dev
 	}
 
 	wcsncpy(string, dev->device_info->manufacturer_string, maxlen);
-	string[maxlen] = L'\0';
+	string[maxlen - 1] = L'\0';
 
 	return 0;
 }
@@ -1102,7 +1102,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_product_string(hid_device *dev, wch
 
 
 	wcsncpy(string, dev->device_info->product_string, maxlen);
-	string[maxlen] = L'\0';
+	string[maxlen - 1] = L'\0';
 
 	return 0;
 }
@@ -1123,7 +1123,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *de
 
 
 	wcsncpy(string, dev->device_info->serial_number, maxlen);
-	string[maxlen] = L'\0';
+	string[maxlen - 1] = L'\0';
 
 	return 0;
 }


### PR DESCRIPTION

code segment (from: [hidtest](https://github.com/libusb/hidapi/blob/master/hidtest/test.c)):

```C
#define MAX_STR 255
wchar_t wstr[MAX_STR];             // !!! <----- wstr[255]; 0~254;

// Read the Manufacturer String
wstr[0] = 0x0000;
res = hid_get_manufacturer_string(handle, wstr, MAX_STR);

int HID_API_EXPORT_CALL HID_API_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
{
	if (!dev->device_info)
	{
		register_string_error(dev, L"NULL device/info");
		return -1;
	}

	if (!string || !maxlen)
	{
		register_string_error(dev, L"Zero buffer/length");
		return -1;
	}


	wcsncpy(string, dev->device_info->product_string, maxlen);
	string[maxlen] = L'\0';      // !!! <----- string[255] = L'\0'; boom!
        // fixed: string[maxlen - 1] = L'\0';

	return 0;
}
```