### PR TITLE
Fix Cygwin Appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,3 @@
-os: Visual Studio 2015
-
 environment:
   matrix:
   - BUILD_ENV: msbuild
@@ -14,6 +12,8 @@ for:
       only:
         - BUILD_ENV: msbuild
 
+    os: Visual Studio 2015
+
     build_script:
       - cmd: msbuild .\windows\hidapi.sln /p:Configuration=Release /p:Platform=%arch% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
@@ -21,6 +21,8 @@ for:
     matrix:
       only:
         - BUILD_ENV: cygwin
+
+    os: Visual Studio 2022
 
     install:
       - cmd: C:\cygwin64\setup-x86_64.exe --quiet-mode --no-shortcuts --upgrade-also --packages autoconf,automake


### PR DESCRIPTION
- run Cygwin on a newer environment;
- keep MSVC running on VS 2015, just to cover automated testing of it;

Fixes: #419