### PR TITLE
Add hid_get_device_info

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -470,6 +470,18 @@ extern "C" {
 		*/
 		int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen);
 
+		/** @brief Get The stuct #hid_device_info from a HID device.
+
+			@ingroup API
+			@param dev A device handle returned from hid_open().
+
+			@returns
+				This function returns a pointer to the struct #hid_device_info
+				for this hid_device, or NULL in the case of failure.
+				This struct is valid until the device is closed with hid_close()
+		*/
+		struct hid_device_info HID_API_EXPORT *HID_API_CALL hid_get_device_info(hid_device *dev);
+
 		/** @brief Get a string from a HID device, based on its string index.
 
 			@ingroup API

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -480,6 +480,8 @@ extern "C" {
 				for this hid_device, or NULL in the case of failure.
 				Call hid_error(dev) to get the failure reason.
 				This struct is valid until the device is closed with hid_close().
+
+			@note The returned object is owned by the @p dev, and SHOULD NOT be freed by the user.
 		*/
 		HID_API_EXPORT struct hid_device_info * HID_API_CALL hid_get_device_info(hid_device *dev);
 

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -480,7 +480,7 @@ extern "C" {
 				for this hid_device, or NULL in the case of failure.
 				This struct is valid until the device is closed with hid_close().
 		*/
-		struct hid_device_info HID_API_EXPORT *HID_API_CALL hid_get_device_info(hid_device *dev);
+		HID_API_EXPORT struct hid_device_info * HID_API_CALL hid_get_device_info(hid_device *dev);
 
 		/** @brief Get a string from a HID device, based on its string index.
 

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -478,7 +478,7 @@ extern "C" {
 			@returns
 				This function returns a pointer to the struct #hid_device_info
 				for this hid_device, or NULL in the case of failure.
-				This struct is valid until the device is closed with hid_close()
+				This struct is valid until the device is closed with hid_close().
 		*/
 		struct hid_device_info HID_API_EXPORT *HID_API_CALL hid_get_device_info(hid_device *dev);
 

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -470,7 +470,7 @@ extern "C" {
 		*/
 		int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen);
 
-		/** @brief Get The stuct #hid_device_info from a HID device.
+		/** @brief Get The struct #hid_device_info from a HID device.
 
 			@ingroup API
 			@param dev A device handle returned from hid_open().

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -478,6 +478,7 @@ extern "C" {
 			@returns
 				This function returns a pointer to the struct #hid_device_info
 				for this hid_device, or NULL in the case of failure.
+				Call hid_error(dev) to get the failure reason.
 				This struct is valid until the device is closed with hid_close().
 		*/
 		HID_API_EXPORT struct hid_device_info * HID_API_CALL hid_get_device_info(hid_device *dev);

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -51,6 +51,17 @@
 #endif
 //
 
+void print_device(struct hid_device_info *cur_dev) {
+	printf("Device Found\n  type: %04hx %04hx\n  path: %s\n  serial_number: %ls", cur_dev->vendor_id, cur_dev->product_id, cur_dev->path, cur_dev->serial_number);
+	printf("\n");
+	printf("  Manufacturer: %ls\n", cur_dev->manufacturer_string);
+	printf("  Product:      %ls\n", cur_dev->product_string);
+	printf("  Release:      %hx\n", cur_dev->release_number);
+	printf("  Interface:    %d\n",  cur_dev->interface_number);
+	printf("  Usage (page): 0x%hx (0x%hx)\n", cur_dev->usage, cur_dev->usage_page);
+	printf("\n");
+}
+
 int main(int argc, char* argv[])
 {
 	(void)argc;
@@ -85,14 +96,7 @@ int main(int argc, char* argv[])
 	devs = hid_enumerate(0x0, 0x0);
 	cur_dev = devs;
 	while (cur_dev) {
-		printf("Device Found\n  type: %04hx %04hx\n  path: %s\n  serial_number: %ls", cur_dev->vendor_id, cur_dev->product_id, cur_dev->path, cur_dev->serial_number);
-		printf("\n");
-		printf("  Manufacturer: %ls\n", cur_dev->manufacturer_string);
-		printf("  Product:      %ls\n", cur_dev->product_string);
-		printf("  Release:      %hx\n", cur_dev->release_number);
-		printf("  Interface:    %d\n",  cur_dev->interface_number);
-		printf("  Usage (page): 0x%hx (0x%hx)\n", cur_dev->usage, cur_dev->usage_page);
-		printf("\n");
+		print_device(cur_dev);
 		cur_dev = cur_dev->next;
 	}
 	hid_free_enumeration(devs);
@@ -133,6 +137,13 @@ int main(int argc, char* argv[])
 		printf("Unable to read serial number string\n");
 	printf("Serial Number String: (%d) %ls", wstr[0], wstr);
 	printf("\n");
+
+	struct hid_device_info* info = hid_get_device_info(handle);
+	if (info == NULL) {
+		printf("Unable to get device info\n");
+	} else {
+		print_device(info);
+	}
 
 	// Read Indexed String 1
 	wstr[0] = 0x0000;

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -62,6 +62,13 @@ void print_device(struct hid_device_info *cur_dev) {
 	printf("\n");
 }
 
+void print_devices(struct hid_device_info *cur_dev) {
+	while (cur_dev) {
+		print_device(cur_dev);
+		cur_dev = cur_dev->next;
+	}
+}
+
 int main(int argc, char* argv[])
 {
 	(void)argc;
@@ -74,7 +81,7 @@ int main(int argc, char* argv[])
 	hid_device *handle;
 	int i;
 
-	struct hid_device_info *devs, *cur_dev;
+	struct hid_device_info *devs;
 
 	printf("hidapi test/example tool. Compiled with hidapi version %s, runtime version %s.\n", HID_API_VERSION_STR, hid_version_str());
 	if (HID_API_VERSION == HID_API_MAKE_VERSION(hid_version()->major, hid_version()->minor, hid_version()->patch)) {
@@ -94,11 +101,7 @@ int main(int argc, char* argv[])
 #endif
 
 	devs = hid_enumerate(0x0, 0x0);
-	cur_dev = devs;
-	while (cur_dev) {
-		print_device(cur_dev);
-		cur_dev = cur_dev->next;
-	}
+	print_devices(devs);
 	hid_free_enumeration(devs);
 
 	// Set up the command buffer.
@@ -142,7 +145,7 @@ int main(int argc, char* argv[])
 	if (info == NULL) {
 		printf("Unable to get device info\n");
 	} else {
-		print_device(info);
+		print_devices(info);
 	}
 
 	// Read Indexed String 1

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -703,12 +703,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 #ifdef __ANDROID__
 						if (handle) {
 							/* There is (a potential) libusb Android backend, in which
-							device descriptor is not accurate up until the device is opened.
-							https://github.com/libusb/libusb/pull/874#discussion_r632801373
-							A workaround is to re-read the descriptor again.
-							Even if it is not going to be accepted into libusb master,
-							having it here won't do any harm, since reading the device descriptor
-							is as cheap as copy 18 bytes of data. */
+							   device descriptor is not accurate up until the device is opened.
+							   https://github.com/libusb/libusb/pull/874#discussion_r632801373
+							   A workaround is to re-read the descriptor again.
+							   Even if it is not going to be accepted into libusb master,
+							   having it here won't do any harm, since reading the device descriptor
+							   is as cheap as copy 18 bytes of data. */
 							libusb_get_device_descriptor(dev, &desc);
 						}
 #endif

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -604,7 +604,7 @@ static void invasive_fill_device_info_usage(struct hid_device_info * cur_dev, li
 
 	res = libusb_claim_interface(handle, interface_num);
 	if (res >= 0) {
-		fill_device_info_usage(cur_dev, handle, interface_num)
+		fill_device_info_usage(cur_dev, handle, interface_num);
 
 		/* Release the interface */
 		res = libusb_release_interface(handle, interface_num);

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -740,7 +740,9 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 							optional. For composite devices, use the interface
 							field in the hid_device_info struct to distinguish
 							between interfaces. */
-							invasive_fill_device_info_usage(tmp, handle, intf_desc->bInterfaceNumber);
+							if (handle) {
+								invasive_fill_device_info_usage(tmp, handle, intf_desc->bInterfaceNumber);
+							}
 #endif /* INVASIVE_GET_USAGE */
 
 							if (cur_dev) {

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -571,7 +571,7 @@ static void fill_device_info_usage(struct hid_device_info * cur_dev, libusb_devi
 	unsigned short page = 0, usage = 0;
 
 	/* Get the HID Report Descriptor. */
-	res = libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN|LIBUSB_RECIPIENT_INTERFACE, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_REPORT << 8)|interface_num, 0, data, sizeof(data), 5000);
+	int res = libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN|LIBUSB_RECIPIENT_INTERFACE, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_REPORT << 8)|interface_num, 0, data, sizeof(data), 5000);
 	if (res >= 0) {
 		/* Parse the usage and usage page
 		   out of the report descriptor. */

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -565,7 +565,7 @@ int HID_API_EXPORT hid_exit(void)
 /**
  * Requires an opened device with *claimed interface*.
  */
-static void fill_device_info_usage(struct hid_device_info * cur_dev, libusb_device_handle *handle, int interface_num)
+static void fill_device_info_usage(struct hid_device_info *cur_dev, libusb_device_handle *handle, int interface_num)
 {
 	unsigned char data[4096];
 	unsigned short page = 0, usage = 0;
@@ -585,7 +585,7 @@ static void fill_device_info_usage(struct hid_device_info * cur_dev, libusb_devi
 }
 
 #ifdef INVASIVE_GET_USAGE
-static void invasive_fill_device_info_usage(struct hid_device_info * cur_dev, libusb_device_handle *handle, int interface_num)
+static void invasive_fill_device_info_usage(struct hid_device_info *cur_dev, libusb_device_handle *handle, int interface_num)
 {
 	int res = 0;
 

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -700,7 +700,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 
 						res = libusb_open(dev, &handle);
 
-						#ifdef __ANDROID__
+#ifdef __ANDROID__
 							if (handle) {
 								/* There is (a potential) libusb Android backend, in which
 								device descriptor is not accurate up until the device is opened.
@@ -711,7 +711,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 								is as cheap as copy 18 bytes of data. */
 								libusb_get_device_descriptor(dev, &desc);
 							}
-						#endif
+#endif
 
 						fill_device_info_for_device(handle, cur_dev, &desc);
 

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -617,7 +617,7 @@ static struct hid_device_info * create_device_info_for_device(libusb_device_hand
 #ifdef DETACH_KERNEL_DRIVER
 		int detached = 0;
 		/* Usage Page and Usage */
-		res = libusb_kernel_driver_active(handle, interface_num);
+		int res = libusb_kernel_driver_active(handle, interface_num);
 		if (res == 1) {
 			res = libusb_detach_kernel_driver(handle, interface_num);
 			if (res < 0)

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -578,7 +578,7 @@ static void fill_device_info_usage(struct hid_device_info * cur_dev, libusb_devi
 		get_usage(data, res,  &page, &usage);
 	}
 	else
-		LOG("libusb_control_transfer() for getting the HID descriptor failed with %d: %s\n", res, libusb_error_name(res));
+		LOG("libusb_control_transfer() for getting the HID report descriptor failed with %d: %s\n", res, libusb_error_name(res));
 
 	cur_dev->usage_page = page;
 	cur_dev->usage = usage;

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -927,7 +927,7 @@ static int hidapi_initialize_device(hid_device *dev, const struct libusb_interfa
 	int i =0;
 	int res = 0;
 	struct libusb_device_descriptor desc;
-	libusb_get_device_descriptor(libusb_get_device(dev->device_handle), &desc);	
+	libusb_get_device_descriptor(libusb_get_device(dev->device_handle), &desc);
 
 	dev->device_info = (struct hid_device_info*) calloc(1, sizeof(struct hid_device_info));
 	dev->device_info->next = NULL;

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -644,7 +644,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 {
 	libusb_device **devs;
 	libusb_device *dev;
-	libusb_device_handle *handle;
+	libusb_device_handle *handle = NULL;
 	ssize_t num_devs;
 	int i = 0;
 
@@ -701,16 +701,16 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 						res = libusb_open(dev, &handle);
 
 #ifdef __ANDROID__
-							if (handle) {
-								/* There is (a potential) libusb Android backend, in which
-								device descriptor is not accurate up until the device is opened.
-								https://github.com/libusb/libusb/pull/874#discussion_r632801373
-								A workaround is to re-read the descriptor again.
-								Even if it is not going to be accepted into libusb master,
-								having it here won't do any harm, since reading the device descriptor
-								is as cheap as copy 18 bytes of data. */
-								libusb_get_device_descriptor(dev, &desc);
-							}
+						if (handle) {
+							/* There is (a potential) libusb Android backend, in which
+							device descriptor is not accurate up until the device is opened.
+							https://github.com/libusb/libusb/pull/874#discussion_r632801373
+							A workaround is to re-read the descriptor again.
+							Even if it is not going to be accepted into libusb master,
+							having it here won't do any harm, since reading the device descriptor
+							is as cheap as copy 18 bytes of data. */
+							libusb_get_device_descriptor(dev, &desc);
+						}
 #endif
 
 						fill_device_info_for_device(handle, cur_dev, &desc);

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1479,7 +1479,7 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 	return hid_get_indexed_string(dev, dev->serial_index, string, maxlen);
 }
 
-struct hid_device_info *HID_API_EXPORT_CALL hid_get_device_info(hid_device *dev) {
+HID_API_EXPORT struct hid_device_info *HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
 		// register_device_error(dev, "NULL device/info");

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1131,7 +1131,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_libusb_wrap_sys_device(intptr_t sys
 		goto err;
 	}
 
-	if (!hidapi_initialize_device(dev,  selected_intf_desc))
+	if (!hidapi_initialize_device(dev, selected_intf_desc))
 		goto err;
 
 	if (dev->device_info) {

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -567,7 +567,7 @@ int HID_API_EXPORT hid_exit(void)
  */
 static void fill_device_info_usage(struct hid_device_info * cur_dev, libusb_device_handle *handle, int interface_num)
 {
-	unsigned char data[256];
+	unsigned char data[4096];
 	unsigned short page = 0, usage = 0;
 
 	/* Get the HID Report Descriptor. */

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -575,65 +575,65 @@ static void fill_device_info_for_device(libusb_device_handle *handle, struct hid
 			cur_dev->product_string =
 				get_usb_string(handle, desc->iProduct);
 
-		#ifdef INVASIVE_GET_USAGE
-		{
-			/*
-			This section is removed because it is too
-			invasive on the system. Getting a Usage Page
-			and Usage requires parsing the HID Report
-			descriptor. Getting a HID Report descriptor
-			involves claiming the interface. Claiming the
-			interface involves detaching the kernel driver.
-			Detaching the kernel driver is hard on the system
-			because it will unclaim interfaces (if another
-			app has them claimed) and the re-attachment of
-			the driver will sometimes change /dev entry names.
-			It is for these reasons that this section is
-			#if 0. For composite devices, use the interface
-			field in the hid_device_info struct to distinguish
-			between interfaces. */
-				unsigned char data[256];
-			#ifdef DETACH_KERNEL_DRIVER
-							int detached = 0;
-							/* Usage Page and Usage */
-							res = libusb_kernel_driver_active(handle, interface_num);
-							if (res == 1) {
-								res = libusb_detach_kernel_driver(handle, interface_num);
-								if (res < 0)
-									LOG("Couldn't detach kernel driver, even though a kernel driver was attached.\n");
-								else
-									detached = 1;
-							}
-#endif
-							res = libusb_claim_interface(handle, interface_num);
-							if (res >= 0) {
-								/* Get the HID Report Descriptor. */
-								res = libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN|LIBUSB_RECIPIENT_INTERFACE, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_REPORT << 8)|interface_num, 0, data, sizeof(data), 5000);
-								if (res >= 0) {
-									unsigned short page=0, usage=0;
-									/* Parse the usage and usage page
-									   out of the report descriptor. */
-									get_usage(data, res,  &page, &usage);
-									cur_dev->usage_page = page;
-									cur_dev->usage = usage;
-								}
-								else
-									LOG("libusb_control_transfer() for getting the HID report failed with %d\n", res);
-
-								/* Release the interface */
-								res = libusb_release_interface(handle, interface_num);
-								if (res < 0)
-									LOG("Can't release the interface.\n");
-							}
-							else
-								LOG("Can't claim interface %d\n", res);
+#ifdef INVASIVE_GET_USAGE
+{
+		/*
+		This section is removed because it is too
+		invasive on the system. Getting a Usage Page
+		and Usage requires parsing the HID Report
+		descriptor. Getting a HID Report descriptor
+		involves claiming the interface. Claiming the
+		interface involves detaching the kernel driver.
+		Detaching the kernel driver is hard on the system
+		because it will unclaim interfaces (if another
+		app has them claimed) and the re-attachment of
+		the driver will sometimes change /dev entry names.
+		It is for these reasons that this section is
+		#if 0. For composite devices, use the interface
+		field in the hid_device_info struct to distinguish
+		between interfaces. */
+			unsigned char data[256];
 #ifdef DETACH_KERNEL_DRIVER
-							/* Re-attach kernel driver if necessary. */
-							if (detached) {
-								res = libusb_attach_kernel_driver(handle, interface_num);
-								if (res < 0)
-									LOG("Couldn't re-attach kernel driver.\n");
-							}
+			int detached = 0;
+			/* Usage Page and Usage */
+			res = libusb_kernel_driver_active(handle, interface_num);
+			if (res == 1) {
+				res = libusb_detach_kernel_driver(handle, interface_num);
+				if (res < 0)
+					LOG("Couldn't detach kernel driver, even though a kernel driver was attached.\n");
+				else
+					detached = 1;
+			}
+#endif
+			res = libusb_claim_interface(handle, interface_num);
+			if (res >= 0) {
+				/* Get the HID Report Descriptor. */
+				res = libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN|LIBUSB_RECIPIENT_INTERFACE, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_REPORT << 8)|interface_num, 0, data, sizeof(data), 5000);
+				if (res >= 0) {
+					unsigned short page=0, usage=0;
+					/* Parse the usage and usage page
+						out of the report descriptor. */
+					get_usage(data, res,  &page, &usage);
+					cur_dev->usage_page = page;
+					cur_dev->usage = usage;
+				}
+				else
+					LOG("libusb_control_transfer() for getting the HID report failed with %d\n", res);
+
+				/* Release the interface */
+				res = libusb_release_interface(handle, interface_num);
+				if (res < 0)
+					LOG("Can't release the interface.\n");
+			}
+			else
+				LOG("Can't claim interface %d\n", res);
+#ifdef DETACH_KERNEL_DRIVER
+			/* Re-attach kernel driver if necessary. */
+			if (detached) {
+				res = libusb_attach_kernel_driver(handle, interface_num);
+				if (res < 0)
+					LOG("Couldn't re-attach kernel driver.\n");
+			}
 #endif
 }
 #endif /* INVASIVE_GET_USAGE */

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -612,7 +612,7 @@ static void fill_device_info_for_device(libusb_device_handle *handle, struct hid
 				if (res >= 0) {
 					unsigned short page=0, usage=0;
 					/* Parse the usage and usage page
-						out of the report descriptor. */
+					   out of the report descriptor. */
 					get_usage(data, res,  &page, &usage);
 					cur_dev->usage_page = page;
 					cur_dev->usage = usage;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -495,7 +495,7 @@ next_line:
 }
 
 
-static void get_device_info_for_device(struct udev_device *raw_dev, unsigned short vendor_id, unsigned short product_id, struct hid_device_info ** first_dev, struct hid_device_info ** last_dev)
+static void create_device_info_for_device(struct udev_device *raw_dev, unsigned short vendor_id, unsigned short product_id, struct hid_device_info ** first_dev, struct hid_device_info ** last_dev)
 {
 	struct hid_device_info *cur_dev = NULL;
 	struct hid_device_info *prev_dev = NULL; /* previous device */
@@ -684,7 +684,7 @@ static void get_device_info_for_device(struct udev_device *raw_dev, unsigned sho
 	*last_dev = cur_dev;
 }
 
-struct hid_device_info* get_device_info_for_hid_device(hid_device *dev) {
+struct hid_device_info* create_device_info_for_hid_device(hid_device *dev) {
 	struct udev *udev;
 	struct udev_device *udev_dev;
 	struct stat s;
@@ -711,7 +711,7 @@ struct hid_device_info* get_device_info_for_hid_device(hid_device *dev) {
 	udev_dev = udev_device_new_from_devnum(udev, 'c', s.st_rdev);
 	if (udev_dev) {
 		struct hid_device_info * tmp;
-		get_device_info_for_device(udev_dev, 0, 0, &root, &tmp);
+		create_device_info_for_device(udev_dev, 0, 0, &root, &tmp);
 	}
 
 	udev_device_unref(udev_dev);
@@ -790,7 +790,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 
 		struct hid_device_info * first_dev = NULL;
 		struct hid_device_info * last_dev = NULL;
-		get_device_info_for_device(raw_dev, vendor_id, product_id, &first_dev, &last_dev);
+		create_device_info_for_device(raw_dev, vendor_id, product_id, &first_dev, &last_dev);
 		if (first_dev) {
 			if (cur_dev) {
 				cur_dev->next = first_dev;
@@ -1131,10 +1131,10 @@ HID_API_EXPORT struct hid_device_info *HID_API_CALL hid_get_device_info(hid_devi
 	if (!dev->device_info)
 	{
 		// Lazy initialize device_info
-		dev->device_info = get_device_info_for_hid_device(dev);
+		dev->device_info = create_device_info_for_hid_device(dev);
 	}
 
-	// get_device_info_for_hid_device will set an error if needed
+	// create_device_info_for_hid_device will set an error if needed
 	return dev->device_info;
 }
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -788,8 +788,8 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		sysfs_path = udev_list_entry_get_name(dev_list_entry);
 		raw_dev = udev_device_new_from_syspath(udev, sysfs_path);
 
-		struct hid_device_info * first_dev;
-		struct hid_device_info * last_dev;
+		struct hid_device_info * first_dev = NULL;
+		struct hid_device_info * last_dev = NULL;
 		get_device_info_for_device(raw_dev, vendor_id, product_id, &first_dev, &last_dev);
 		if (first_dev) {
 			if (cur_dev) {

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1065,16 +1065,16 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (!string || !maxlen)
+	{
+		register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
 	struct hid_device_info *info = hid_get_device_info(dev);
 	if (!info)
 	{
 		// hid_get_device_info will have set an error already
-		return -1;
-	}
-
-	if (!string || !maxlen)
-	{
-		register_device_error(dev, "Zero buffer/length");
 		return -1;
 	}
 
@@ -1086,16 +1086,16 @@ int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *st
 
 int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (!string || !maxlen)
+	{
+		register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
 	struct hid_device_info *info = hid_get_device_info(dev);
 	if (!info)
 	{
 		// hid_get_device_info will have set an error already
-		return -1;
-	}
-
-	if (!string || !maxlen)
-	{
-		register_device_error(dev, "Zero buffer/length");
 		return -1;
 	}
 
@@ -1107,16 +1107,16 @@ int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string,
 
 int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (!string || !maxlen)
+	{
+		register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
 	struct hid_device_info *info = hid_get_device_info(dev);
 	if (!info)
 	{
 		// hid_get_device_info will have set an error already
-		return -1;
-	}
-
-	if (!string || !maxlen)
-	{
-		register_device_error(dev, "Zero buffer/length");
 		return -1;
 	}
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -888,8 +888,6 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 	/* If we have a good handle, return it. */
 	if (dev->device_handle >= 0) {
-		dev->device_info = get_device_info_for_hid_device(dev);
-
 		/* Get the report descriptor */
 		int res, desc_size = 0;
 		struct hidraw_report_descriptor rpt_desc;
@@ -1067,9 +1065,10 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info)
+	struct hid_device_info *info = hid_get_device_info(dev);
+	if (!info)
 	{
-		register_device_error(dev, "NULL device/info");
+		// hid_get_device_info will have set an error already
 		return -1;
 	}
 
@@ -1079,7 +1078,7 @@ int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *st
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->manufacturer_string, maxlen);
+	wcsncpy(string, info->manufacturer_string, maxlen);
 	string[maxlen - 1] = L'\0';
 
 	return 0;
@@ -1087,9 +1086,10 @@ int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *st
 
 int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info)
+	struct hid_device_info *info = hid_get_device_info(dev);
+	if (!info)
 	{
-		register_device_error(dev, "NULL device/info");
+		// hid_get_device_info will have set an error already
 		return -1;
 	}
 
@@ -1099,7 +1099,7 @@ int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string,
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->product_string, maxlen);
+	wcsncpy(string, info->product_string, maxlen);
 	string[maxlen - 1] = L'\0';
 
 	return 0;
@@ -1107,9 +1107,10 @@ int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string,
 
 int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info)
+	struct hid_device_info *info = hid_get_device_info(dev);
+	if (!info)
 	{
-		register_device_error(dev, "NULL device/info");
+		// hid_get_device_info will have set an error already
 		return -1;
 	}
 
@@ -1119,7 +1120,7 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->serial_number, maxlen);
+	wcsncpy(string, info->serial_number, maxlen);
 	string[maxlen - 1] = L'\0';
 
 	return 0;
@@ -1129,10 +1130,11 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 HID_API_EXPORT struct hid_device_info *HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
-		register_device_error(dev, "NULL device/info");
-		return NULL;
+		// Lazy initialize device_info
+		dev->device_info = get_device_info_for_hid_device(dev);
 	}
 
+	// get_device_info_for_hid_device will set an error if needed
 	return dev->device_info;
 }
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1126,7 +1126,7 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 }
 
 
-struct hid_device_info *HID_API_EXPORT_CALL hid_get_device_info(hid_device *dev) {
+HID_API_EXPORT struct hid_device_info *HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
 		register_device_error(dev, "NULL device/info");

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -830,8 +830,6 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		goto return_error;
 	}
 
-	dev->device_info = create_device_info(dev->device_handle);
-
 	/* Open the IOHIDDevice */
 	ret = IOHIDDeviceOpen(dev->device_handle, dev->open_options);
 	if (ret == kIOReturnSuccess) {
@@ -1166,9 +1164,10 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info)
+	struct hid_device_info *info = hid_get_device_info(dev);
+	if (!info)
 	{
-		// register_device_error(dev, "NULL device/info");
+		// hid_get_device_info will have set an error already
 		return -1;
 	}
 
@@ -1178,7 +1177,7 @@ int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *st
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->manufacturer_string, maxlen);
+	wcsncpy(string, info->manufacturer_string, maxlen);
 	string[maxlen - 1] = L'\0';
 
 	return 0;
@@ -1186,9 +1185,10 @@ int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *st
 
 int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info)
+	struct hid_device_info *info = hid_get_device_info(dev);
+	if (!info)
 	{
-		// register_device_error(dev, "NULL device/info");
+		// hid_get_device_info will have set an error already
 		return -1;
 	}
 
@@ -1198,7 +1198,7 @@ int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string,
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->product_string, maxlen);
+	wcsncpy(string, info->product_string, maxlen);
 	string[maxlen - 1] = L'\0';
 
 	return 0;
@@ -1206,9 +1206,10 @@ int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string,
 
 int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info)
+	struct hid_device_info *info = hid_get_device_info(dev);
+	if (!info)
 	{
-		// register_device_error(dev, "NULL device/info");
+		// hid_get_device_info will have set an error already
 		return -1;
 	}
 
@@ -1218,7 +1219,7 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->serial_number, maxlen);
+	wcsncpy(string, info->serial_number, maxlen);
 	string[maxlen - 1] = L'\0';
 
 	return 0;
@@ -1227,8 +1228,7 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 HID_API_EXPORT struct hid_device_info *HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
-		// register_string_error(dev, L"NULL device/info");
-		return NULL;
+		dev->device_info = create_device_info(dev->device_handle);
 	}
 
 	return dev->device_info;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -132,6 +132,7 @@ struct hid_device_ {
 	uint8_t *input_report_buf;
 	CFIndex max_input_report_len;
 	struct input_report *input_reports;
+	struct hid_device_info* device_info;
 
 	pthread_t thread;
 	pthread_mutex_t mutex; /* Protects input_reports */
@@ -155,6 +156,7 @@ static hid_device *new_hid_device(void)
 	dev->input_report_buf = NULL;
 	dev->input_reports = NULL;
 	dev->shutdown_thread = 0;
+	dev->device_info = NULL;
 
 	/* Thread objects */
 	pthread_mutex_init(&dev->mutex, NULL);
@@ -187,6 +189,7 @@ static void free_hid_device(hid_device *dev)
 	if (dev->source)
 		CFRelease(dev->source);
 	free(dev->input_report_buf);
+	hid_free_enumeration(dev->device_info);
 
 	/* Clean up the thread objects */
 	pthread_barrier_destroy(&dev->shutdown_barrier);
@@ -827,6 +830,8 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		goto return_error;
 	}
 
+	dev->device_info = create_device_info(dev->device_handle);
+
 	/* Open the IOHIDDevice */
 	ret = IOHIDDeviceOpen(dev->device_handle, dev->open_options);
 	if (ret == kIOReturnSuccess) {
@@ -1161,17 +1166,72 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	return get_manufacturer_string(dev->device_handle, string, maxlen);
+	if (!dev->device_info)
+	{
+		// register_device_error(dev, "NULL device/info");
+		return -1;
+	}
+
+	if (!string || !maxlen)
+	{
+		// register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
+	wcsncpy(string, dev->device_info->manufacturer_string, maxlen);
+	string[maxlen - 1] = L'\0';
+
+	return 0;
 }
 
 int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	return get_product_string(dev->device_handle, string, maxlen);
+	if (!dev->device_info)
+	{
+		// register_device_error(dev, "NULL device/info");
+		return -1;
+	}
+
+	if (!string || !maxlen)
+	{
+		// register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
+	wcsncpy(string, dev->device_info->product_string, maxlen);
+	string[maxlen - 1] = L'\0';
+
+	return 0;
 }
 
 int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	return get_serial_number(dev->device_handle, string, maxlen);
+	if (!dev->device_info)
+	{
+		// register_device_error(dev, "NULL device/info");
+		return -1;
+	}
+
+	if (!string || !maxlen)
+	{
+		// register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
+	wcsncpy(string, dev->device_info->serial_number, maxlen);
+	string[maxlen - 1] = L'\0';
+
+	return 0;
+}
+
+struct hid_device_info *HID_API_EXPORT_CALL hid_get_device_info(hid_device *dev) {
+	if (!dev->device_info)
+	{
+		// register_string_error(dev, L"NULL device/info");
+		return NULL;
+	}
+
+	return dev->device_info;
 }
 
 int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1164,16 +1164,16 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (!string || !maxlen)
+	{
+		// register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
 	struct hid_device_info *info = hid_get_device_info(dev);
 	if (!info)
 	{
 		// hid_get_device_info will have set an error already
-		return -1;
-	}
-
-	if (!string || !maxlen)
-	{
-		// register_device_error(dev, "Zero buffer/length");
 		return -1;
 	}
 
@@ -1185,16 +1185,16 @@ int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *st
 
 int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (!string || !maxlen)
+	{
+		// register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
 	struct hid_device_info *info = hid_get_device_info(dev);
 	if (!info)
 	{
 		// hid_get_device_info will have set an error already
-		return -1;
-	}
-
-	if (!string || !maxlen)
-	{
-		// register_device_error(dev, "Zero buffer/length");
 		return -1;
 	}
 
@@ -1206,16 +1206,16 @@ int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string,
 
 int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (!string || !maxlen)
+	{
+		// register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
 	struct hid_device_info *info = hid_get_device_info(dev);
 	if (!info)
 	{
 		// hid_get_device_info will have set an error already
-		return -1;
-	}
-
-	if (!string || !maxlen)
-	{
-		// register_device_error(dev, "Zero buffer/length");
 		return -1;
 	}
 

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -155,8 +155,8 @@ static hid_device *new_hid_device(void)
 	dev->source = NULL;
 	dev->input_report_buf = NULL;
 	dev->input_reports = NULL;
-	dev->shutdown_thread = 0;
 	dev->device_info = NULL;
+	dev->shutdown_thread = 0;
 
 	/* Thread objects */
 	pthread_mutex_init(&dev->mutex, NULL);

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1224,7 +1224,7 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 	return 0;
 }
 
-struct hid_device_info *HID_API_EXPORT_CALL hid_get_device_info(hid_device *dev) {
+HID_API_EXPORT struct hid_device_info *HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
 		// register_string_error(dev, L"NULL device/info");

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1141,13 +1141,13 @@ void HID_API_EXPORT HID_API_CALL hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL HID_API_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info) {
-		register_string_error(dev, L"NULL device info");
+	if (!string || !maxlen) {
+		register_string_error(dev, L"Zero buffer/length");
 		return -1;
 	}
 
-	if (!string || !maxlen) {
-		register_string_error(dev, L"Zero buffer/length");
+	if (!dev->device_info) {
+		register_string_error(dev, L"NULL device info");
 		return -1;
 	}
 
@@ -1161,13 +1161,13 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_manufacturer_string(hid_device *dev
 
 int HID_API_EXPORT_CALL HID_API_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info) {
-		register_string_error(dev, L"NULL device info");
+	if (!string || !maxlen) {
+		register_string_error(dev, L"Zero buffer/length");
 		return -1;
 	}
 
-	if (!string || !maxlen) {
-		register_string_error(dev, L"Zero buffer/length");
+	if (!dev->device_info) {
+		register_string_error(dev, L"NULL device info");
 		return -1;
 	}
 
@@ -1181,13 +1181,13 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_product_string(hid_device *dev, wch
 
 int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	if (!dev->device_info) {
-		register_string_error(dev, L"NULL device info");
+	if (!string || !maxlen) {
+		register_string_error(dev, L"Zero buffer/length");
 		return -1;
 	}
 
-	if (!string || !maxlen) {
-		register_string_error(dev, L"Zero buffer/length");
+	if (!dev->device_info) {
+		register_string_error(dev, L"NULL device info");
 		return -1;
 	}
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1202,7 +1202,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *de
 HID_API_EXPORT struct hid_device_info * HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
-		register_string_error(dev, L"NULL device/info");
+		register_string_error(dev, L"NULL device info");
 		return NULL;
 	}
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1199,6 +1199,16 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *de
 	return 0;
 }
 
+struct hid_device_info *HID_API_EXPORT_CALL hid_get_device_info(hid_device *dev) {
+	if (!dev->device_info)
+	{
+		register_string_error(dev, L"NULL device/info");
+		return NULL;
+	}
+
+	return dev->device_info;
+}
+
 int HID_API_EXPORT_CALL HID_API_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
 {
 	BOOL res;

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1199,7 +1199,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *de
 	return 0;
 }
 
-struct hid_device_info *HID_API_EXPORT_CALL hid_get_device_info(hid_device *dev) {
+struct hid_device_info *HID_API_EXPORT_CALL HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
 		register_string_error(dev, L"NULL device/info");

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1199,7 +1199,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *de
 	return 0;
 }
 
-struct hid_device_info *HID_API_EXPORT_CALL HID_API_CALL hid_get_device_info(hid_device *dev) {
+HID_API_EXPORT struct hid_device_info * HID_API_CALL hid_get_device_info(hid_device *dev) {
 	if (!dev->device_info)
 	{
 		register_string_error(dev, L"NULL device/info");


### PR DESCRIPTION
Resolves: #431
Closes: #164
Closes: #163

I don't like the signature of `get_device_info_for_device` in linux, and Im unsure about `fill_device_info_for_device` in libusb.

The mac, linux and libusb implementations appear to work fine with hidtest.
I havent tested the other backends yet

