### PR TITLE
linux: Open files with `O_CLOEXEC` to not leak fds to child processes

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -384,7 +384,7 @@ static int get_hid_report_descriptor(const char *rpt_path, struct hidraw_report_
 	int rpt_handle;
 	ssize_t res;
 
-	rpt_handle = open(rpt_path, O_RDONLY);
+	rpt_handle = open(rpt_path, O_RDONLY | O_CLOEXEC);
 	if (rpt_handle < 0) {
 		register_global_error_format("open failed (%s): %s", rpt_path, strerror(errno));
 		return -1;
@@ -473,7 +473,7 @@ static int parse_hid_vid_pid_from_uevent_path(const char *uevent_path, unsigned 
 	int handle;
 	ssize_t res;
 
-	handle = open(uevent_path, O_RDONLY);
+	handle = open(uevent_path, O_RDONLY | O_CLOEXEC);
 	if (handle < 0) {
 		register_global_error_format("open failed (%s): %s", uevent_path, strerror(errno));
 		return 0;
@@ -981,7 +981,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 	dev = new_hid_device();
 
-	dev->device_handle = open(path, O_RDWR);
+	dev->device_handle = open(path, O_RDWR | O_CLOEXEC);
 
 	/* If we have a good handle, return it. */
 	if (dev->device_handle >= 0) {


### PR DESCRIPTION
In general, `open()` should always be called with `O_CLOEXEC`, except immediately before an `exec*` call that will use the fd.

Previously the fd was leaked to a child process, as seen here:

```c

int main() {
    assert(hid_open_path("/dev/hidraw0") > 0);
    char *args[] = {"/bin/sh", "-c", "readlink /proc/self/fd/*", NULL};
    execve("/bin/sh", args, NULL);
}
```

In some cases this could be a security issue if child processes may be less privileged and shouldn't have access to the file.