### PR TITLE
CI: add OpenBSD compilation test

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -2,7 +2,7 @@ image: openbsd/latest
 packages:
 - cmake
 - pkgconf
-- libusb1
+- libusb1--
 - libiconv
 - ninja
 sources:

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,0 +1,19 @@
+image: openbsd/latest
+packages:
+- cmake
+- pkgconf
+- libusb1
+- libiconv
+- ninja
+sources:
+- https://github.com/libusb/hidapi
+tasks:
+- setup: |
+    cd hidapi
+    mkdir -p build install
+    cmake -GNinja -B build -S . -DCMAKE_INSTALL_PREFIX=install
+- build: |
+    cd hidapi/build
+    ninja
+    ninja install
+    ninja clean


### PR DESCRIPTION
NOTES, as described in https://github.com/libusb/hidapi/pull/31:
- it is still not easy to use HIDAPI on OpenBSD since it is not easy to use LIBUSB to replace the HID driver;
- there is a name colision with `hid_init` from [`usbhid`](https://man.openbsd.org/usbhid.3) OpenBSD library;

Closes: https://github.com/libusb/hidapi/pull/31