### PR TITLE
libusb: stop `read_thread` from looping indefinitely (#456)

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -952,6 +952,7 @@ static void read_callback(struct libusb_transfer *transfer)
 
 static void *read_thread(void *param)
 {
+	int res;
 	hid_device *dev = param;
 	uint8_t *buf;
 	const size_t length = dev->input_ep_max_packet_size;
@@ -970,14 +971,18 @@ static void *read_thread(void *param)
 
 	/* Make the first submission. Further submissions are made
 	   from inside read_callback() */
-	libusb_submit_transfer(dev->transfer);
+	res = libusb_submit_transfer(dev->transfer);
+	if(res < 0) {
+                LOG("libusb_submit_transfer failed: %d %s. Stopping read_thread from running\n", res, libusb_error_name(res));
+                dev->shutdown_thread = 1;
+                dev->transfer_loop_finished = 1;
+	}
 
 	/* Notify the main thread that the read thread is up and running. */
 	pthread_barrier_wait(&dev->barrier);
 
 	/* Handle all the events. */
 	while (!dev->shutdown_thread) {
-		int res;
 		res = libusb_handle_events(usb_context);
 		if (res < 0) {
 			/* There was an error. */


### PR DESCRIPTION
- When `libusb_submit_transfer` in `read_thread` fails, `read_callback` never gets called and never sets `transfer_loop_finished` to true, causing `read_thread` to loop indefinitely.

- Fix this by skipping the handle_events for the transfer

- Fixes #456