### PR TITLE
Fix "warning C4996: 'wcsncpy': This function or variable may be unsafe." by using wcsncpy_s instead

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1182,8 +1182,12 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_manufacturer_string(hid_device *dev
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->manufacturer_string, maxlen);
+	errno_t err = wcsncpy_s(string, maxlen, dev->device_info->manufacturer_string, MAX_STRING_WCHARS);
 	string[maxlen - 1] = L'\0';
+
+	if (err) {
+		register_string_error(dev, L"Buffer to small");
+	}
 
 	register_string_error(dev, NULL);
 
@@ -1202,8 +1206,12 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_product_string(hid_device *dev, wch
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->product_string, maxlen);
+	errno_t err = wcsncpy_s(string, maxlen, dev->device_info->product_string, MAX_STRING_WCHARS);
 	string[maxlen - 1] = L'\0';
+
+	if (err) {
+		register_string_error(dev, L"Buffer to small");
+	}
 
 	register_string_error(dev, NULL);
 
@@ -1222,8 +1230,12 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *de
 		return -1;
 	}
 
-	wcsncpy(string, dev->device_info->serial_number, maxlen);
+	errno_t err = wcsncpy_s(string, maxlen, dev->device_info->serial_number, MAX_STRING_WCHARS);
 	string[maxlen - 1] = L'\0';
+
+	if (err) {
+		register_string_error(dev, L"Buffer to small");
+	}
 
 	register_string_error(dev, NULL);
 


### PR DESCRIPTION
This is a fix for the warnings (build fail) of #467 
See: https://github.com/libusb/hidapi/actions/runs/3260495512/jobs/5354096398

```
D:\a\hidapi\hidapi\hidapisrc\windows\hid.c(1185,2): error C2220: the following warning is treated as an error [D:\a\hidapi\hidapi\build\msvc\src\windows\pp_data_dump\pp_data_dump.vcxproj]
D:\a\hidapi\hidapi\hidapisrc\windows\hid.c(1185,2): warning C4996: 'wcsncpy': This function or variable may be unsafe. Consider using wcsncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\hidapi\hidapi\build\msvc\src\windows\pp_data_dump\pp_data_dump.vcxproj]
D:\a\hidapi\hidapi\hidapisrc\windows\hid.c(1205,2): warning C4996: 'wcsncpy': This function or variable may be unsafe. Consider using wcsncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\hidapi\hidapi\build\msvc\src\windows\pp_data_dump\pp_data_dump.vcxproj]
D:\a\hidapi\hidapi\hidapisrc\windows\hid.c(1225,2): warning C4996: 'wcsncpy': This function or variable may be unsafe. Consider using wcsncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [D:\a\hidapi\hidapi\build\msvc\src\windows\pp_data_dump\pp_data_dump.vcxproj]
```
Please review if `MAX_STRING_WCHARS` is the right value here.