### PR TITLE
README example: prevent segmentation fault and mixture of printf/wprintf

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,19 @@ int main(int argc, char* argv[])
 
 	// Read the Manufacturer String
 	res = hid_get_manufacturer_string(handle, wstr, MAX_STR);
-	wprintf(L"Manufacturer String: %s\n", wstr);
+	wprintf(L"Manufacturer String: %ls\n", wstr);
 
 	// Read the Product String
 	res = hid_get_product_string(handle, wstr, MAX_STR);
-	wprintf(L"Product String: %s\n", wstr);
+	wprintf(L"Product String: %ls\n", wstr);
 
 	// Read the Serial Number String
 	res = hid_get_serial_number_string(handle, wstr, MAX_STR);
-	wprintf(L"Serial Number String: (%d) %s\n", wstr[0], wstr);
+	wprintf(L"Serial Number String: (%d) %ls\n", wstr[0], wstr);
 
 	// Read Indexed String 1
 	res = hid_get_indexed_string(handle, 1, wstr, MAX_STR);
-	wprintf(L"Indexed String 1: %s\n", wstr);
+	wprintf(L"Indexed String 1: %ls\n", wstr);
 
 	// Toggle LED (cmd 0x80). The first byte is the report number (0x0).
 	buf[0] = 0x0;

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ int main(int argc, char* argv[])
 	handle = hid_open(0x4d8, 0x3f, NULL);
 	if (!handle) {
 		printf("Unable to open device\n");
+
+		hid_exit()
  		return 1;
 	}
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ int main(int argc, char* argv[])
 	// Open the device using the VID, PID,
 	// and optionally the Serial number.
 	handle = hid_open(0x4d8, 0x3f, NULL);
+	if (!handle) {
+		printf("Unable to open device\n");
+ 		return 1;
+	}
 
 	// Read the Manufacturer String
 	res = hid_get_manufacturer_string(handle, wstr, MAX_STR);

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ device spec. Writing data (`hid_write`) at random to your HID devices can break 
 
 ```c
 #include <stdio.h> // printf
-#include <wchar.h> // wprintf
+#include <wchar.h> // wchar_t
 
 #include <hidapi.h>
 
@@ -124,19 +124,19 @@ int main(int argc, char* argv[])
 
 	// Read the Manufacturer String
 	res = hid_get_manufacturer_string(handle, wstr, MAX_STR);
-	wprintf(L"Manufacturer String: %ls\n", wstr);
+	printf("Manufacturer String: %ls\n", wstr);
 
 	// Read the Product String
 	res = hid_get_product_string(handle, wstr, MAX_STR);
-	wprintf(L"Product String: %ls\n", wstr);
+	printf("Product String: %ls\n", wstr);
 
 	// Read the Serial Number String
 	res = hid_get_serial_number_string(handle, wstr, MAX_STR);
-	wprintf(L"Serial Number String: (%d) %ls\n", wstr[0], wstr);
+	printf("Serial Number String: (%d) %ls\n", wstr[0], wstr);
 
 	// Read Indexed String 1
 	res = hid_get_indexed_string(handle, 1, wstr, MAX_STR);
-	wprintf(L"Indexed String 1: %ls\n", wstr);
+	printf("Indexed String 1: %ls\n", wstr);
 
 	// Toggle LED (cmd 0x80). The first byte is the report number (0x0).
 	buf[0] = 0x0;


### PR DESCRIPTION
When no device is connected (or user doesn't have permission to access
device), hid_open returns NULL.  If NULL is passed to
hid_get_manufacturer_string(), it crashes with SIGSEGV, which could be
confusing to newcomers trying to get example to work.

wprintf and printf aren't compatible in the same stream

Now it's more similar to https://github.com/libusb/hidapi/blob/master/hidtest/test.c#L129

Closes: #469