### PR TITLE
Link gcc helpers statically on MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,7 @@ case $host in
 	os="windows"
 	threads="windows"
 	win_implementation="mingw"
+	LDFLAGS="${LDFLAGS} -static-libgcc"
 	;;
 *-msys*)
 	AC_MSG_RESULT([ (Windows back-end, using MSYS2)])
@@ -130,6 +131,7 @@ case $host in
 	os="windows"
 	threads="windows"
 	win_implementation="mingw"
+	LDFLAGS="${LDFLAGS} -static-libgcc"
 	;;
 *-cygwin*)
 	AC_MSG_RESULT([ (Windows back-end, using Cygwin)])


### PR DESCRIPTION
When compiling a 32bit dll with the mingw-w64 compiler, some 64bit integer arithmetic operations are implemented using functions from libgcc (e.g. __udivdi3 and __umoddi3 from libgcc_s_dw2-1.dll). This unexpected dependency is inconvenient for applications.

The run-time dependency can be avoid by linking statically.