### PR TITLE
Upgrade checkout and file-existence-action actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install build tools
       run: brew install autoconf automake libtool
     - name: Configure Automake
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: hidapisrc
     - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       working-directory: build/framework
       run: make install
     - name: Check artifacts
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "install/shared/lib/libhidapi.dylib, \
                 install/shared/include/hidapi/hidapi.h, \
@@ -66,7 +66,7 @@ jobs:
                 install/framework/lib/hidapi.framework/hidapi, \
                 install/framework/lib/hidapi.framework/Headers/hidapi.h, \
                 install/framework/lib/hidapi.framework/Headers/hidapi_darwin.h"
-        allow_failure: true
+        fail: true
     - name: Check CMake Export Package Shared
       run: |
         cmake \
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: hidapisrc
     - name: Install dependencies
@@ -119,7 +119,7 @@ jobs:
       working-directory: build/static
       run: make install
     - name: Check artifacts
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "install/shared/lib/libhidapi-libusb.so, \
                 install/shared/lib/libhidapi-hidraw.so, \
@@ -129,7 +129,7 @@ jobs:
                 install/static/lib/libhidapi-hidraw.a, \
                 install/static/include/hidapi/hidapi.h, \
                 install/static/include/hidapi/hidapi_libusb.h"
-        allow_failure: true
+        fail: true
     - name: Check CMake Export Package Shared
       run: |
         cmake \
@@ -162,7 +162,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: hidapisrc
     - name: Install dependencies
@@ -178,13 +178,13 @@ jobs:
       working-directory: build/msvc
       run: cmake --build . --target install
     - name: Check artifacts MSVC
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "install/msvc/lib/hidapi.lib, \
                 install/msvc/bin/hidapi.dll, \
                 install/msvc/include/hidapi/hidapi.h, \
                 install/msvc/include/hidapi/hidapi_winapi.h"
-        allow_failure: true
+        fail: true
     - name: Check CMake Export Package
       shell: cmd
       run: |
@@ -209,13 +209,13 @@ jobs:
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         nmake install
     - name: Check artifacts NMake
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "install/nmake/lib/hidapi.lib, \
                 install/nmake/bin/hidapi.dll, \
                 install/nmake/include/hidapi/hidapi.h, \
                 install/nmake/include/hidapi/hidapi_winapi.h"
-        allow_failure: true
+        fail: true
     - name: Check CMake Export Package NMake
       shell: cmd
       run: |
@@ -238,13 +238,13 @@ jobs:
       working-directory: build\mingw
       run: cmake --build . --target install
     - name: Check artifacts MinGW
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "install/mingw/lib/libhidapi.dll.a, \
                 install/mingw/bin/libhidapi.dll, \
                 install/mingw/include/hidapi/hidapi.h, \
                 install/mingw/include/hidapi/hidapi_winapi.h"
-        allow_failure: true
+        fail: true
     - name: Check CMake Export Package MinGW
       shell: cmd
       run: |
@@ -271,22 +271,22 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: microsoft/setup-msbuild@v1.1
     - name: MSBuild x86
       run: msbuild windows\hidapi.sln /p:Configuration=Release /p:Platform=Win32
     - name: Check artifacts x86
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "windows/Release/hidapi.dll, windows/Release/hidapi.lib, windows/Release/hidapi.pdb"
-        allow_failure: true
+        fail: true
     - name: MSBuild x64
       run: msbuild windows\hidapi.sln /p:Configuration=Release /p:Platform=x64
     - name: Check artifacts x64
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "windows/x64/Release/hidapi.dll, windows/x64/Release/hidapi.lib, windows/x64/Release/hidapi.pdb"
-        allow_failure: true
+        fail: true
     - name: Gather artifacts
       run: |
         md artifacts


### PR DESCRIPTION
The old versions are deprecated due to usage of Node.js 12.