### PR TITLE
Get descriptor (windows fixes)

### DIFF
--- a/windows/hidapi_descriptor_reconstruct.c
+++ b/windows/hidapi_descriptor_reconstruct.c
@@ -342,9 +342,13 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 					for (HIDP_REPORT_TYPE rt_idx = 0; rt_idx < NUM_OF_HIDP_REPORT_TYPES; rt_idx++) {
 						for (int reportid_idx = 0; reportid_idx < 256; reportid_idx++) {
 							for (int child_idx = 1; child_idx < coll_number_of_direct_childs[collection_node_idx]; child_idx++) {
-								if ((coll_bit_range[child_idx - 1][reportid_idx][rt_idx]->FirstBit != -1) &&
-									(coll_bit_range[child_idx][reportid_idx][rt_idx]->FirstBit != -1) &&
-									(coll_bit_range[child_idx - 1][reportid_idx][rt_idx]->FirstBit > coll_bit_range[child_idx][reportid_idx][rt_idx]->FirstBit)) {
+								// since the coll_bit_range array is not sorted, we need to reference the collection index in 
+								// our sorted coll_child_order array, and look up the corresponding bit ranges for comparing values to sort
+								int prev_coll_idx = coll_child_order[collection_node_idx][child_idx - 1];
+								int cur_coll_idx = coll_child_order[collection_node_idx][child_idx];
+								if ((coll_bit_range[prev_coll_idx][reportid_idx][rt_idx]->FirstBit != -1) &&
+									(coll_bit_range[cur_coll_idx][reportid_idx][rt_idx]->FirstBit != -1) &&
+									(coll_bit_range[prev_coll_idx][reportid_idx][rt_idx]->FirstBit > coll_bit_range[cur_coll_idx][reportid_idx][rt_idx]->FirstBit)) {
 									// Swap position indices of the two compared child collections
 									USHORT idx_latch = coll_child_order[collection_node_idx][child_idx - 1];
 									coll_child_order[collection_node_idx][child_idx - 1] = coll_child_order[collection_node_idx][child_idx];
@@ -562,7 +566,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 					int padding = 8 - ((last_bit_position[rt_idx][reportid_idx] + 1) % 8);
 					if (padding < 8) {
 						// Insert padding item after item referenced in last_report_item_lookup
-						rd_insert_main_item_node(last_bit_position[rt_idx][reportid_idx], last_bit_position[rt_idx][reportid_idx] + padding, rd_item_node_padding, -1, 0, (rd_main_items) rt_idx, (unsigned char) reportid_idx, &last_report_item_lookup[rt_idx][reportid_idx]);
+						rd_insert_main_item_node(last_bit_position[rt_idx][reportid_idx] + 1, last_bit_position[rt_idx][reportid_idx] + padding, rd_item_node_padding, -1, 0, (rd_main_items) rt_idx, (unsigned char) reportid_idx, &last_report_item_lookup[rt_idx][reportid_idx]);
 					}
 				}
 			}

--- a/windows/hidapi_descriptor_reconstruct.c
+++ b/windows/hidapi_descriptor_reconstruct.c
@@ -566,7 +566,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 					int padding = 8 - ((last_bit_position[rt_idx][reportid_idx] + 1) % 8);
 					if (padding < 8) {
 						// Insert padding item after item referenced in last_report_item_lookup
-						rd_insert_main_item_node(last_bit_position[rt_idx][reportid_idx] + 1, last_bit_position[rt_idx][reportid_idx] + padding, rd_item_node_padding, -1, 0, (rd_main_items) rt_idx, (unsigned char) reportid_idx, &last_report_item_lookup[rt_idx][reportid_idx]);
+						rd_insert_main_item_node(last_bit_position[rt_idx][reportid_idx] + 1, last_bit_position[rt_idx][reportid_idx] + 1 + padding, rd_item_node_padding, -1, 0, (rd_main_items) rt_idx, (unsigned char) reportid_idx, &last_report_item_lookup[rt_idx][reportid_idx]);
 					}
 				}
 			}

--- a/windows/hidapi_descriptor_reconstruct.c
+++ b/windows/hidapi_descriptor_reconstruct.c
@@ -543,6 +543,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				// INPUT, OUTPUT or FEATURE
 				if (list->FirstBit != -1) {
 					if ((last_bit_position[list->MainItemType][list->ReportID] + 1 != list->FirstBit) &&
+						(last_report_item_lookup[list->MainItemType][list->ReportID] != NULL) &&
 						(last_report_item_lookup[list->MainItemType][list->ReportID]->FirstBit != list->FirstBit) // Happens in case of IsMultipleItemsForArray for multiple dedicated usages for a multi-button array
 						) {
 						struct rd_main_item_node *list_node = rd_search_main_item_list_for_bit_position(last_bit_position[list->MainItemType][list->ReportID], list->MainItemType, list->ReportID, &last_report_item_lookup[list->MainItemType][list->ReportID]);


### PR DESCRIPTION
Hello @JoergAtGithub and @Youw, First off, thank you both for your work on supporting reading/reconstructing report descriptors within this hidapi get-descriptors branch. It has been helpful for a project I've been working on.

I believe I've found a few small errors on windows within the reconstruction process that I'm submitting for your review and consideration merging back to the main hidapi repository. Thank you in advance for your attention.

The first commit is simply a null pointer test, which may be irrelevant now that I'm successfully sorting collection bit ranges, but harmless to include and might future proof other problematic cases. 

The second commit contains two changes: 

1. The sorting of child collections based on bit ranges was not working properly for me while testing with an xbox controller for example. As best I could tell, as the code was comparing and sorting values in coll_child_order array, it was not using the appropriate collection index for looking up the bit ranges, and assuming that the coll_child_order array indexing and the coll_bit_range array indexing were the same. I believe there is a level of indirection here that is necessary to take into account as reflected in the changeset. Without this change, child collections were not properly sorted and then the code would try to insert padding where there should be none. 
2. The final bit padding as far as I could tell, had an off by one bug. I needed to add one to mark the correct bits of padding without overlapping the final valid bit in the report. 