### PR TITLE
Unified the target output directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ unset(_build_type_index)
 
 project(hidapi LANGUAGES C)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
 if(APPLE)
     if(NOT CMAKE_VERSION VERSION_LESS "3.15")
         option(CMAKE_FRAMEWORK "Build macOS/iOS Framework version of the library" OFF)


### PR DESCRIPTION
It's hard to run or debug the the test executable program because the library and test target are compiled in seperate directories