### PR TITLE
windows: don't mark with dllexport in static build

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -7,7 +7,7 @@
 
  libusb/hidapi Team
 
- Copyright 2022, All Rights Reserved.
+ Copyright 2023, All Rights Reserved.
 
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
@@ -30,10 +30,15 @@
 #include <wchar.h>
 
 #ifdef _WIN32
+   /* #480: this is to be refactored properly for v1.0 */
+   #ifndef HID_API_EXPORT
       #define HID_API_EXPORT __declspec(dllexport)
+   #endif
       #define HID_API_CALL
 #else
+   #ifndef HID_API_EXPORT
       #define HID_API_EXPORT /**< API export macro */
+   #endif
       #define HID_API_CALL /**< API call macro */
 #endif
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -20,6 +20,14 @@ target_link_libraries(hidapi_winapi
     PUBLIC hidapi_include
 )
 
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(hidapi_winapi
+        # prevent marking functions as __declspec(dllexport) for static library build
+        # #480: this should be refactored for v1.0
+        PUBLIC HID_API_EXPORT
+    )
+endif()
+
 set_target_properties(hidapi_winapi
     PROPERTIES
         EXPORT_NAME "winapi"


### PR DESCRIPTION
Don't mark API functions with `__declspec(dllexport)` when building a static library on Windows.
Enforced by CMake builds.
For other builds a compile definition is available.

Related: #480