### PR TITLE
win: Have a separate definition flag for export

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -29,18 +29,17 @@
 
 #include <wchar.h>
 
+/* #480: this is to be refactored properly for v1.0 */
 #ifdef _WIN32
-   /* #480: this is to be refactored properly for v1.0 */
-   #ifndef HID_API_EXPORT
+   #ifndef HID_API_NO_EXPORT_DEFINE
       #define HID_API_EXPORT __declspec(dllexport)
    #endif
-      #define HID_API_CALL
-#else
-   #ifndef HID_API_EXPORT
-      #define HID_API_EXPORT /**< API export macro */
-   #endif
-      #define HID_API_CALL /**< API call macro */
 #endif
+#ifndef HID_API_EXPORT
+   #define HID_API_EXPORT /**< API export macro */
+#endif
+/* To be removed in v1.0 */
+#define HID_API_CALL /**< API call macro */
 
 #define HID_API_EXPORT_CALL HID_API_EXPORT HID_API_CALL /**< API export and call macro*/
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(hidapi_winapi
         # prevent marking functions as __declspec(dllexport) for static library build
         # #480: this should be refactored for v1.0
-        PUBLIC HID_API_EXPORT
+        PUBLIC HID_API_NO_EXPORT_DEFINE
     )
 endif()
 


### PR DESCRIPTION
On some compilers an empty definition (e.g. -DHID_API_EXPORT) means the same as =1 (e.g. -DHID_API_EXPORT=1), but the HID_API_EXPORT macro should be empty in static library build case.

Having a separate compiler definition flag solves that issue.

Closes: #512
Relates: #480 