### PR TITLE
libusb: fix crash in hid_enumerate() caused by a stale device handle

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -833,8 +833,10 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 							cur_dev = tmp;
 						}
 
-						if (res >= 0)
+						if (res >= 0) {
 							libusb_close(handle);
+							handle = NULL;
+						}
 					}
 				} /* altsettings */
 			} /* interfaces */


### PR DESCRIPTION
When hid_enumerate() iterates over the device list, it's possible that libusb_open() fails. If this occurs on the next round after a successful libusb_open() call, create_device_info_for_device() is passed the previous iteration's already closed device handle.

Fix the crash by setting the handle to NULL after libusb_close().