### PR TITLE
hidapi/libusb: use LIBUSB_CALL for the read_callback function

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -899,7 +899,7 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const
 	return handle;
 }
 
-static void read_callback(struct libusb_transfer *transfer)
+static void LIBUSB_CALL read_callback(struct libusb_transfer *transfer)
 {
 	hid_device *dev = transfer->user_data;
 	int res;


### PR DESCRIPTION
This is important if libusb and hidapi have been built with different calling conventions