### PR TITLE
Fixed parameter documentation mismatch

### DIFF
--- a/windows/hidapi_descriptor_reconstruct.c
+++ b/windows/hidapi_descriptor_reconstruct.c
@@ -46,7 +46,7 @@ static void rd_append_byte(unsigned char byte, struct rd_buffer* rpt_desc) {
  *
  * @param[in]  rd_item  Enumeration identifying type (Main, Global, Local) and function (e.g Usage or Report Count) of the item.
  * @param[in]  data     Data (Size depends on rd_item 0,1,2 or 4bytes).
- * @param      list     Chained list of report descriptor bytes.
+ * @param      rpt_desc Pointer to report descriptor buffer struct.
  *
  * @return Returns 0 if successful, -1 for error.
  */

--- a/windows/hidapi_winapi.h
+++ b/windows/hidapi_winapi.h
@@ -46,7 +46,7 @@ extern "C" {
 
 			@ingroup API
 			@param dev A device handle returned from hid_open().
-			@param guid The device's container ID on return.
+			@param container_id The device's container ID on return.
 
 			@returns
 				This function returns 0 on success and -1 on error.


### PR DESCRIPTION
This fixes build warnings with -Wdocumentation (and build failures if your build has warnings as errors enabled)