### PR TITLE
hidapi/mac: fixed crash on macOS when AirPods are connected

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -376,7 +376,7 @@ static int get_string_property(IOHIDDeviceRef device, CFStringRef prop, wchar_t 
 
 	buf[0] = 0;
 
-	if (str) {
+	if (str && CFGetTypeID(str) == CFStringGetTypeID()) {
 		CFIndex str_len = CFStringGetLength(str);
 		CFRange range;
 		CFIndex used_buf_len;


### PR DESCRIPTION
There's a macOS bug with some devices where string properties aren't actually strings, and this prevents a crash when this happens. Specifically we ran into this with Apple AirPods.