### PR TITLE
Fixed double-free during multi-threaded hidapi access

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -129,8 +129,19 @@ static wchar_t *utf8_to_wchar_t(const char *utf8)
  * Use register_error_str(NULL) to free the error message completely. */
 static void register_error_str(wchar_t **error_str, const char *msg)
 {
-	free(*error_str);
-	*error_str = utf8_to_wchar_t(msg);
+	wchar_t *old_string;
+#ifdef HIDAPI_ATOMIC_SET_POINTER
+	old_string = HIDAPI_ATOMIC_SET_POINTER(error_str, NULL);
+#else
+	old_string = *error_str; *error_str = NULL;
+#endif
+	if (old_string) {
+		free(old_string);
+	}
+
+	if (msg) {
+		*error_str = utf8_to_wchar_t(msg);
+	}
 }
 
 /* Semilar to register_error_str, but allows passing a format string with va_list args into this function. */

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -238,8 +238,19 @@ static wchar_t *utf8_to_wchar_t(const char *utf8)
  * Use register_error_str(NULL) to free the error message completely. */
 static void register_error_str(wchar_t **error_str, const char *msg)
 {
-	free(*error_str);
-	*error_str = utf8_to_wchar_t(msg);
+	wchar_t *old_string;
+#ifdef HIDAPI_ATOMIC_SET_POINTER
+	old_string = HIDAPI_ATOMIC_SET_POINTER(error_str, NULL);
+#else
+	old_string = *error_str; *error_str = NULL;
+#endif
+	if (old_string) {
+		free(old_string);
+	}
+
+	if (msg) {
+		*error_str = utf8_to_wchar_t(msg);
+	}
 }
 
 /* Similar to register_error_str, but allows passing a format string with va_list args into this function. */

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -228,8 +228,15 @@ static void free_hid_device(hid_device *dev)
 
 static void register_winapi_error_to_buffer(wchar_t **error_buffer, const WCHAR *op)
 {
-	free(*error_buffer);
-	*error_buffer = NULL;
+	wchar_t *old_string;
+#ifdef HIDAPI_ATOMIC_SET_POINTER
+	old_string = HIDAPI_ATOMIC_SET_POINTER(error_buffer, NULL);
+#else
+	old_string = *error_buffer; *error_buffer = NULL;
+#endif
+	if (old_string) {
+		free(old_string);
+	}
 
 	/* Only clear out error messages if NULL is passed into op */
 	if (!op) {
@@ -293,8 +300,15 @@ static void register_winapi_error_to_buffer(wchar_t **error_buffer, const WCHAR 
 
 static void register_string_error_to_buffer(wchar_t **error_buffer, const WCHAR *string_error)
 {
-	free(*error_buffer);
-	*error_buffer = NULL;
+	wchar_t *old_string;
+#ifdef HIDAPI_ATOMIC_SET_POINTER
+	old_string = HIDAPI_ATOMIC_SET_POINTER(error_buffer, NULL);
+#else
+	old_string = *error_buffer; *error_buffer = NULL;
+#endif
+	if (old_string) {
+		free(old_string);
+	}
 
 	if (string_error) {
 		*error_buffer = _wcsdup(string_error);


### PR DESCRIPTION
The error string is not protected by a mutex, and can be set from multiple threads at the same time. Without this change, it can be double-freed. It can still be double-allocated, leading to a memory leak, but at least it won't crash now.