### PR TITLE
Fix various typo

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -11,7 +11,7 @@ Ludovic Rousseau <rousseau@debian.org>:
 	Correctness fixes
 
 libusb/hidapi Team:
-	Development/maintainance since June 4th 2019
+	Development/maintenance since June 4th 2019
 
 For a comprehensive list of contributions, see the commit list at github:
 	https://github.com/libusb/hidapi/graphs/contributors

--- a/BUILD.cmake.md
+++ b/BUILD.cmake.md
@@ -16,7 +16,7 @@ most of this document may not be of interest for you; just check variables names
 CMake can be installed either using your system's package manager,
 or by downloading an installer/prebuilt version from the [official website](https://cmake.org/download/).
 
-On most \*nix systems, the prefered way to install CMake is via package manager,
+On most \*nix systems, the preferred way to install CMake is via package manager,
 e.g. `sudo apt install cmake`.
 
 On Windows CMake could be provided by your development environment (e.g. by Visual Studio Installer or MinGW installer),

--- a/libusb/CMakeLists.txt
+++ b/libusb/CMakeLists.txt
@@ -66,7 +66,7 @@ else()
         else()
             # otherwise there is 2 options:
             # 1) iconv is provided by Standard C library and the build will be just fine
-            # 2) The _user_ has to provide additiona compilation options for this project/target
+            # 2) The _user_ has to provide additional compilation options for this project/target
         endif()
 
         # check for error: "conflicting types for 'iconv'"

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -508,7 +508,7 @@ static int hid_get_report_descriptor_libusb(libusb_device_handle *handle, int in
 		expected_report_descriptor_size = HID_API_MAX_REPORT_DESCRIPTOR_SIZE;
 
 	/* Get the HID Report Descriptor.
-	   See USB HID Specificatin, sectin 7.1.1
+	   See USB HID Specification, section 7.1.1
 	*/
 	int res = libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN|LIBUSB_RECIPIENT_INTERFACE, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_REPORT << 8), interface_num, tmp, expected_report_descriptor_size, 5000);
 	if (res < 0) {

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -351,7 +351,7 @@ static int get_next_hid_usage(__u8 *report_descriptor, __u32 size, unsigned int 
 
 /*
  * Retrieves the hidraw report descriptor from a file.
- * When using this form, <sysfs_path>/device/report_descriptor, elevated priviledges are not required.
+ * When using this form, <sysfs_path>/device/report_descriptor, elevated privileges are not required.
  */
 static int get_hid_report_descriptor(const char *rpt_path, struct hidraw_report_descriptor *rpt_desc)
 {
@@ -910,7 +910,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			}
 			cur_dev = tmp;
 
-			/* move the pointer to the tail of returnd list */
+			/* move the pointer to the tail of returned list */
 			while (cur_dev->next != NULL) {
 				cur_dev = cur_dev->next;
 			}

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -769,7 +769,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		}
 		cur_dev = tmp;
 
-		/* move the pointer to the tail of returnd list */
+		/* move the pointer to the tail of returned list */
 		while (cur_dev->next != NULL) {
 			cur_dev = cur_dev->next;
 		}

--- a/udev/69-hid.rules
+++ b/udev/69-hid.rules
@@ -17,7 +17,7 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="003f", TAG+="uacc
 
 # Once done, optionally rename this file for your application, and drop it into
 # /etc/udev/rules.d/.
-# NOTE: these rules must have priorty before 73-seat-late.rules.
+# NOTE: these rules must have priority before 73-seat-late.rules.
 # (Small discussion/explanation in systemd repo:
 #  https://github.com/systemd/systemd/issues/4288#issuecomment-348166161)
 # for example, name the file /etc/udev/rules.d/70-my-application-hid.rules.

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -206,7 +206,7 @@ static hid_device *new_hid_device()
 	memset(&dev->ol, 0, sizeof(dev->ol));
 	dev->ol.hEvent = CreateEvent(NULL, FALSE, FALSE /*initial state f=nonsignaled*/, NULL);
 	memset(&dev->write_ol, 0, sizeof(dev->write_ol));
-	dev->write_ol.hEvent = CreateEvent(NULL, FALSE, FALSE /*inital state f=nonsignaled*/, NULL);
+	dev->write_ol.hEvent = CreateEvent(NULL, FALSE, FALSE /*initial state f=nonsignaled*/, NULL);
 	dev->device_info = NULL;
 
 	return dev;

--- a/windows/hidapi_descriptor_reconstruct.c
+++ b/windows/hidapi_descriptor_reconstruct.c
@@ -235,7 +235,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 	}
 
 	// *************************************************************************
-	// -Determine hierachy levels of each collections and store it in:
+	// -Determine hierarchy levels of each collections and store it in:
 	//  coll_levels[COLLECTION_INDEX]
 	// -Determine number of direct childs of each collections and store it in:
 	//  coll_number_of_direct_childs[COLLECTION_INDEX]
@@ -303,10 +303,10 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 		}
 	}
 
-	// *************************************************************************************************
-	// Determine child collection order of the whole hierachy, based on previously determined bit ranges
+	// **************************************************************************************************
+	// Determine child collection order of the whole hierarchy, based on previously determined bit ranges
 	// and store it this index coll_child_order[COLLECTION_INDEX][DIRECT_CHILD_INDEX]
-	// *************************************************************************************************
+	// **************************************************************************************************
 	USHORT **coll_child_order;
 	coll_child_order = malloc(pp_data->NumberLinkCollectionNodes * sizeof(*coll_child_order));
 	{
@@ -326,7 +326,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				{
 					// Create list of child collection indices
 					// sorted reverse to the order returned to HidP_GetLinkCollectionNodeschild
-					// which seems to match teh original order, as long as no bit position needs to be considered
+					// which seems to match the original order, as long as no bit position needs to be considered
 					USHORT child_idx = link_collection_nodes[collection_node_idx].FirstChild;
 					int child_count = coll_number_of_direct_childs[collection_node_idx] - 1;
 					coll_child_order[collection_node_idx][child_count] = child_idx;

--- a/windows/test/hid_report_reconstructor_test.c
+++ b/windows/test/hid_report_reconstructor_test.c
@@ -129,7 +129,7 @@ static hidp_preparsed_data * alloc_preparsed_data_from_file(char* filename)
 				pp_data->caps_info[rt_idx].ReportByteLength = temp_ushort;
 				continue;
 			}
-			fprintf(stderr, "Ignorring unimplemented caps_info field: %s", line);
+			fprintf(stderr, "Ignoring unimplemented caps_info field: %s", line);
 			continue;
 		}
 
@@ -259,7 +259,7 @@ static hidp_preparsed_data * alloc_preparsed_data_from_file(char* filename)
 					pp_data->caps[caps_idx].UnknownTokens[token_idx].BitField = temp_ulong;
 					continue;
 				}
-				fprintf(stderr, "Ignorring unimplemented pp_data->cap[]->pp_cap->UnknownTokens field: %s", line);
+				fprintf(stderr, "Ignoring unimplemented pp_data->cap[]->pp_cap->UnknownTokens field: %s", line);
 				continue;
 			}
 
@@ -383,7 +383,7 @@ static hidp_preparsed_data * alloc_preparsed_data_from_file(char* filename)
 				pp_data->caps[caps_idx].Reserved1[2] = temp_uchar[2];
 				continue;
 			}
-			fprintf(stderr, "Ignorring unimplemented cap field: %s", line);
+			fprintf(stderr, "Ignoring unimplemented cap field: %s", line);
 			continue;
 		}
 
@@ -433,7 +433,7 @@ static hidp_preparsed_data * alloc_preparsed_data_from_file(char* filename)
 				pcoll[coll_idx].Reserved = temp_ulong;
 				continue;
 			}
-			fprintf(stderr, "Ignorring unimplemented LinkCollectionArray field: %s", line);
+			fprintf(stderr, "Ignoring unimplemented LinkCollectionArray field: %s", line);
 			continue;
 		}
 	}


### PR DESCRIPTION
Found via `codespell -q 3 -L childs,fo,xwindows`
Encountered in downstream https://github.com/libsdl-org/SDL