### PR TITLE
hidraw: report only Top-Level Usage_page/Usage pairs as 'unique' devices 

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -250,8 +250,16 @@ static int get_usage(uint8_t *report_descriptor, size_t size,
 			//printf("Usage Page: %x\n", (uint32_t)*usage_page);
 		}
 		if (key_cmd == 0x8) {
-			*usage = get_bytes(report_descriptor, size, data_len, i);
-			usage_found = 1;
+			if (data_len == 4) { /* Usages 5.5 / Usage Page 6.2.2.7 */
+				*usage_page = get_bytes(report_descriptor, size, 2, i + 2);
+				usage_page_found = 1;
+				*usage = get_bytes(report_descriptor, size, 2, i);
+				usage_found = 1;
+			}
+			else {
+				*usage = get_bytes(report_descriptor, size, data_len, i);
+				usage_found = 1;
+			}
 			//printf("Usage: %x\n", (uint32_t)*usage);
 		}
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -316,7 +316,7 @@ static int hid_iterate_over_collection(__u8 *report_descriptor, __u32 size, unsi
 		*pos += *data_len + *key_size;
 	}
 
-	return 0; /* Did not found the end of a Collection */
+	return 0; /* Did not find the end of a Collection */
 }
 
 /*

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -192,7 +192,7 @@ static wchar_t *copy_udev_string(struct udev_device *dev, const char *udev_name)
  * Returns 1 if successful, 0 if an invalid key
  * Sets data_len and key_size when successful
  */
-static int get_hid_item_size(__u8 *report_descriptor, __u32 size, unsigned int pos, int *data_len, int *key_size)
+static int get_hid_item_size(const __u8 *report_descriptor, __u32 size, unsigned int pos, int *data_len, int *key_size)
 {
 	int key = report_descriptor[pos];
 	int size_code;
@@ -248,7 +248,7 @@ static int get_hid_item_size(__u8 *report_descriptor, __u32 size, unsigned int p
  * Get bytes from a HID Report Descriptor.
  * Only call with a num_bytes of 0, 1, 2, or 4.
  */
-static __u32 get_hid_report_bytes(__u8 *rpt, size_t len, size_t num_bytes, size_t cur)
+static __u32 get_hid_report_bytes(const __u8 *rpt, size_t len, size_t num_bytes, size_t cur)
 {
 	/* Return if there aren't enough bytes. */
 	if (cur + num_bytes >= len)
@@ -280,7 +280,7 @@ static __u32 get_hid_report_bytes(__u8 *rpt, size_t len, size_t num_bytes, size_
  * 0 when error is occured (broken Descriptor, end of a Collection is found before its begin,
  *  or no Collection is found at all).
  */
-static int hid_iterate_over_collection(__u8 *report_descriptor, __u32 size, unsigned int *pos, int *data_len, int *key_size)
+static int hid_iterate_over_collection(const __u8 *report_descriptor, __u32 size, unsigned int *pos, int *data_len, int *key_size)
 {
 	int collection_level = 0;
 
@@ -319,6 +319,12 @@ static int hid_iterate_over_collection(__u8 *report_descriptor, __u32 size, unsi
 	return 0; /* Did not find the end of a Collection */
 }
 
+struct hid_usage_iterator {
+	unsigned int pos;
+	int usage_page_found;
+	unsigned short usage_page;
+};
+
 /*
  * Retrieves the device's Usage Page and Usage from the report descriptor.
  * The algorithm returns the current Usage Page/Usage pair whenever a new
@@ -336,40 +342,48 @@ static int hid_iterate_over_collection(__u8 *report_descriptor, __u32 size, unsi
  * 1 when finished processing descriptor.
  * -1 on a malformed report.
  */
-static int get_next_hid_usage(__u8 *report_descriptor, __u32 size, unsigned int *pos, unsigned short *usage_page, unsigned short *usage)
+static int get_next_hid_usage(const __u8 *report_descriptor, __u32 size, struct hid_usage_iterator *ctx, unsigned short *usage_page, unsigned short *usage)
 {
 	int data_len, key_size;
-	int initial = *pos == 0; /* Used to handle case where no top-level application collection is defined */
+	int initial = ctx->pos == 0; /* Used to handle case where no top-level application collection is defined */
 
 	int usage_found = 0;
-	int usage_page_found = 0;
 
-	while (*pos < size) {
-		int key = report_descriptor[*pos];
+	while (ctx->pos < size) {
+		int key = report_descriptor[ctx->pos];
 		int key_cmd = key & 0xfc;
 
 		/* Determine data_len and key_size */
-		if (!get_hid_item_size(report_descriptor, size, *pos, &data_len, &key_size))
+		if (!get_hid_item_size(report_descriptor, size, ctx->pos, &data_len, &key_size))
 			return -1; /* malformed report */
 
 		switch (key_cmd) {
 		case 0x4: /* Usage Page 6.2.2.7 (Global) */
-			*usage_page = get_hid_report_bytes(report_descriptor, size, data_len, *pos);
-			usage_page_found = 1;
+			ctx->usage_page = get_hid_report_bytes(report_descriptor, size, data_len, ctx->pos);
+			ctx->usage_page_found = 1;
 			break;
 
 		case 0x8: /* Usage 6.2.2.8 (Local) */
-			*usage = get_hid_report_bytes(report_descriptor, size, data_len, *pos);
-			usage_found = 1;
+			if (data_len == 4) { /* Usages 5.5 / Usage Page 6.2.2.7 */
+				ctx->usage_page = get_hid_report_bytes(report_descriptor, size, 2, ctx->pos + 2);
+				ctx->usage_page_found = 1;
+				*usage = get_hid_report_bytes(report_descriptor, size, 2, ctx->pos);
+				usage_found = 1;
+			}
+			else {
+				*usage = get_hid_report_bytes(report_descriptor, size, data_len, ctx->pos);
+				usage_found = 1;
+			}
 			break;
 
 		case 0xa0: /* Collection 6.2.2.4 (Main) */
-			if (!hid_iterate_over_collection(report_descriptor, size, pos, &data_len, &key_size)) {
+			if (!hid_iterate_over_collection(report_descriptor, size, &ctx->pos, &data_len, &key_size)) {
 				return -1;
 			}
 
 			/* A pair is valid - to be reported when Collection is found */
-			if (usage_found && usage_page_found) {
+			if (usage_found && ctx->usage_page_found) {
+				*usage_page = ctx->usage_page;
 				return 0;
 			}
 
@@ -377,13 +391,15 @@ static int get_next_hid_usage(__u8 *report_descriptor, __u32 size, unsigned int 
 		}
 
 		/* Skip over this key and its associated data */
-		*pos += data_len + key_size;
+		ctx->pos += data_len + key_size;
 	}
 
 	/* If no top-level application collection is found and usage page/usage pair is found, pair is valid
 	   https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/top-level-collections */
-	if (initial && usage_found && usage_page_found)
-		return 0; /* success */
+	if (initial && usage_found && ctx->usage_page_found) {
+			*usage_page = ctx->usage_page;
+			return 0; /* success */
+	}
 
 	return 1; /* finished processing */
 }
@@ -766,12 +782,14 @@ static struct hid_device_info * create_device_info_for_device(struct udev_device
 	result = get_hid_report_descriptor_from_sysfs(sysfs_path, &report_desc);
 	if (result >= 0) {
 		unsigned short page = 0, usage = 0;
-		unsigned int pos = 0;
+		struct hid_usage_iterator usage_iterator;
+		memset(&usage_iterator, 0, sizeof(usage_iterator));
+
 		/*
 		 * Parse the first usage and usage page
 		 * out of the report descriptor.
 		 */
-		if (!get_next_hid_usage(report_desc.value, report_desc.size, &pos, &page, &usage)) {
+		if (!get_next_hid_usage(report_desc.value, report_desc.size, &usage_iterator, &page, &usage)) {
 			cur_dev->usage_page = page;
 			cur_dev->usage = usage;
 		}
@@ -780,7 +798,7 @@ static struct hid_device_info * create_device_info_for_device(struct udev_device
 		 * Parse any additional usage and usage pages
 		 * out of the report descriptor.
 		 */
-		while (!get_next_hid_usage(report_desc.value, report_desc.size, &pos, &page, &usage)) {
+		while (!get_next_hid_usage(report_desc.value, report_desc.size, &usage_iterator, &page, &usage)) {
 			/* Create new record for additional usage pairs */
 			struct hid_device_info *tmp = (struct hid_device_info*) calloc(1, sizeof(struct hid_device_info));
 			struct hid_device_info *prev_dev = cur_dev;


### PR DESCRIPTION
To be consistent with Windows/macOS (OS-level implementations).

Fixes: #298
Fixes: #454