### PR TITLE
CI: Fix Archlinux build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -400,7 +400,7 @@ jobs:
     - name: Install dependencies
       run: |
         pacman -Sy
-        pacman -S --noconfirm gcc pkg-config autoconf automake libtool libusb libudev0 cmake make
+        pacman -S --noconfirm glibc lib32-glibc gcc pkg-config autoconf automake libtool libusb libudev0 cmake make
     - name: Configure CMake
       run: |
         rm -rf build install


### PR DESCRIPTION
Apparently when installing/upgrading packages on Archlinux - need to explicitly make sure `glibc` is upgraded as well.

Fixes: #607