### PR TITLE
macOS: Check for macOS 10.10 using kCFCoreFoundationVersionNumber instead of AppKit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ case $host in
 	backend="mac"
 	os="darwin"
 	threads="pthreads"
-	LIBS="${LIBS} -framework IOKit -framework CoreFoundation -framework AppKit"
+	LIBS="${LIBS} -framework IOKit -framework CoreFoundation"
 	;;
 *-freebsd*)
 	AC_MSG_RESULT([ (FreeBSD back-end)])

--- a/dist/hidapi.podspec
+++ b/dist/hidapi.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |spec|
 
   spec.public_header_files = "hidapi/hidapi.h", "mac/hidapi_darwin.h"
 
-  spec.frameworks   = "IOKit", "CoreFoundation", "AppKit"
+  spec.frameworks   = "IOKit", "CoreFoundation"
 
 end

--- a/mac/CMakeLists.txt
+++ b/mac/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Threads REQUIRED)
 target_link_libraries(hidapi_darwin
     PUBLIC hidapi_include
     PRIVATE Threads::Threads
-    PRIVATE "-framework IOKit" "-framework CoreFoundation" "-framework AppKit"
+    PRIVATE "-framework IOKit" "-framework CoreFoundation"
 )
 
 set_target_properties(hidapi_darwin

--- a/mac/Makefile-manual
+++ b/mac/Makefile-manual
@@ -12,7 +12,7 @@ CC=gcc
 COBJS=hid.o ../hidtest/test.o
 OBJS=$(COBJS)
 CFLAGS+=-I../hidapi -I. -Wall -g -c
-LIBS=-framework IOKit -framework CoreFoundation -framework AppKit
+LIBS=-framework IOKit -framework CoreFoundation
 
 
 hidtest: $(OBJS)

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -38,9 +38,6 @@
 
 #include "hidapi_darwin.h"
 
-/* As defined in AppKit.h, but we don't need the entire AppKit for a single constant. */
-extern const double NSAppKitVersionNumber;
-
 /* Barrier implementation because Mac OSX doesn't have pthread_barrier.
    It also doesn't have clock_gettime(). So much for POSIX and SUSv2.
    This implementation came from Brent Priddy and was posted on
@@ -466,7 +463,7 @@ int HID_API_EXPORT hid_init(void)
 	register_global_error(NULL);
 
 	if (!hid_mgr) {
-		is_macos_10_10_or_greater = (NSAppKitVersionNumber >= 1343); /* NSAppKitVersionNumber10_10 */
+		is_macos_10_10_or_greater = (kCFCoreFoundationVersionNumber >= 1151.16); /* kCFCoreFoundationVersionNumber10_10 */
 		hid_darwin_set_open_exclusive(1); /* Backward compatibility */
 		return init_hid_manager();
 	}


### PR DESCRIPTION
Fixes: #587