### PR TITLE
Only enumerate each interface once

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -885,6 +885,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 							libusb_close(handle);
 							handle = NULL;
 						}
+						break;
 					}
 				} /* altsettings */
 			} /* interfaces */


### PR DESCRIPTION
If a device has multiple altsettings, like an Xbox Series X controller, make sure we only enumerate each interface once, not once for each altsetting.