### PR TITLE
windows: change MAX_STRING_WCHARS to 126

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -790,6 +790,10 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 		if (detect_bus_type_result.bus_flags & HID_API_BUS_FLAG_BLE)
 			hid_internal_get_ble_info(dev, detect_bus_type_result.dev_node);
 		break;
+
+	default:
+		/* shut down -Wswitch */
+		break;
 	}
 
 	return dev;

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -793,7 +793,9 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 			hid_internal_get_ble_info(dev, detect_bus_type_result.dev_node);
 		break;
 
-	default:
+	case HID_API_BUS_UNKNOWN:
+	case HID_API_BUS_SPI:
+	case HID_API_BUS_I2C:
 		/* shut down -Wswitch */
 		break;
 	}


### PR DESCRIPTION
Win32 HID API doc says: For USB devices, the maximum string length is 126 wide characters (not including the terminating NULL character).

For certain USB devices, using a buffer larger or equal to 127 wchars results in successful completion of HID API functions, but a broken string is stored in the output buffer. This behaviour persists even if HID API is bypassed and HID IOCTLs are passed to the HID driver directly (IOCTL_HID_GET_MANUFACTURER_STRING, IOCTL_HID_GET_PRODUCT_STRING, etc).

So, the buffer MUST NOT exceed 126 wchars.