### PR TITLE
Disable -Wformat-extra-args form MinGW

### DIFF
--- a/windows/test/hid_report_reconstructor_test.c
+++ b/windows/test/hid_report_reconstructor_test.c
@@ -6,6 +6,7 @@
 
 #if defined(__MINGW32__)
 #pragma GCC diagnostic ignored "-Wformat"
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
 #endif
 static hidp_preparsed_data * alloc_preparsed_data_from_file(char* filename)
 {


### PR DESCRIPTION
It seems that the warning implementations for the format strings in MinGW compiler and MinGW std-crt are not in sync: https://stackoverflow.com/questions/68900199/how-to-get-mingw-gcc-to-recognize-the-zu-format-specifier-for-size-t/68907731#68907731

I don't know a better solution than disabling this check.