### PR TITLE
Don't try to memcpy() to a NULL destination.

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1185,7 +1185,9 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 	   return buffer (data), and delete the liked list item. */
 	struct input_report *rpt = dev->input_reports;
 	size_t len = (length < rpt->len)? length: rpt->len;
-	memcpy(data, rpt->data, len);
+	if (data != NULL) {
+		memcpy(data, rpt->data, len);
+	}
 	dev->input_reports = rpt->next;
 	free(rpt->data);
 	free(rpt);


### PR DESCRIPTION
This function is called with a literal NULL for that pointer later in the file.

We had a user run into this in SDL; checking for NULL before memcpy()'ing resolved it.