### PR TITLE
Fix hanging GetOverlappedResult() when closing device

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1279,15 +1279,14 @@ void HID_API_EXPORT HID_API_CALL hid_close(hid_device *dev)
 		return;
 
 	/* Cancel I/O specifically for overlapped operations. There are cases
-	 * where CancelIo() does _not_ cancel the associated overlapped
-	 * operations, causing GetOverlappedResult() to hang forever for
-	 * read/write operations.
-	 *
-	 * This is also the recommended way of cancelling pending overlapped
-	 * operations according to:
-	 *
-	 * https://learn.microsoft.com/en-us/windows/win32/fileio/canceling-pending-i-o-operations
-     */
+	   where CancelIo() does _not_ cancel the associated overlapped
+	   operations, causing GetOverlappedResult() to hang forever for
+	   read/write operations.
+
+	   This is also the recommended way of cancelling pending overlapped
+	   operations according to:
+
+	   https://learn.microsoft.com/en-us/windows/win32/fileio/canceling-pending-i-o-operations */
 	CancelIoEx(dev->device_handle, &dev->ol);
 	CancelIoEx(dev->device_handle, &dev->write_ol);
 


### PR DESCRIPTION
This fixes:

https://github.com/libusb/hidapi/issues/650