### PR TITLE
Deadlock prevention patch for Connection-callback feature

### DIFF
--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -22,11 +22,12 @@
 
 #include <hidapi.h>
 
-// Headers needed for sleeping.
+// Headers needed for sleeping and console management (wait for a keypress)
 #ifdef _WIN32
 	#include <windows.h>
     #include <conio.h>
 #else
+    #include <fcntl.h>
     #include <termios.h>
 	#include <unistd.h>
 #endif

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -60,7 +60,7 @@
 // Used for immediate response in interactive subroutines
 // Taken from:
 // https://cboard.cprogramming.com/c-programming/63166-kbhit-linux.html
-int waitkey()
+int waitkey(void)
 {
 #ifdef _WIN32
 	return _getch();
@@ -448,7 +448,7 @@ int cb1_func(hid_hotplug_callback_handle callback_handle,
 	return 1;
 }
 
-void test_hotplug_deadlocks()
+void test_hotplug_deadlocks(void)
 {
 	cb_test1_triggered = 0;
 	printf("Starting the Hotplug callbacks deadlocks test\n");
@@ -463,7 +463,7 @@ void test_hotplug_deadlocks()
 //
 // CLI
 
-void print_version_check()
+void print_version_check(void)
 {
 	printf("hidapi test/example tool. Compiled with hidapi version %s, runtime version %s.\n", HID_API_VERSION_STR, hid_version_str());
 	if (HID_API_VERSION == HID_API_MAKE_VERSION(hid_version()->major, hid_version()->minor, hid_version()->patch)) {
@@ -474,7 +474,7 @@ void print_version_check()
 	}
 }
 
-void interactive_loop()
+void interactive_loop(void)
 {
 	int command = 0;
 

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -457,6 +457,9 @@ void test_hotplug_deadlocks(void)
 	hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, cb1_func, NULL, &cb1_handle);
 
 	printf("Test finished successfully (at least no deadlocks were found)\n");
+
+    // Intentionally leave a callback registered to test how hid_exit handles it
+    //hid_hotplug_deregister_callback(cb2_handle);
 }
 
 
@@ -508,9 +511,11 @@ void interactive_loop(void)
 			test_device();
 			break;
 		case '4':
-			test_hotplug_deadlocks();
+            test_hotplug_deadlocks();
+            break;
 		case 'Q':
-			break;
+            printf("Quitting.\n");
+            return;
 		default:
 			printf("Command not recognized\n");
 			break;

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -25,6 +25,7 @@
 // Headers needed for sleeping.
 #ifdef _WIN32
 	#include <windows.h>
+    #include <conio.h>
 #else
 	#include <unistd.h>
 #endif
@@ -50,8 +51,40 @@
 #if defined(USING_HIDAPI_LIBUSB) && HID_API_VERSION >= HID_API_MAKE_VERSION(0, 12, 0)
 #include <hidapi_libusb.h>
 #endif
+
+//
+// A function that waits for a key to be pressed and reports it's code
+// Used for immediate response in interactive subroutines
+// Taken from:
+// https://cboard.cprogramming.com/c-programming/63166-kbhit-linux.html
+int waitkey()
+{
+#ifdef _WIN32
+    return _getch();
+#else
+    struct termios oldt, newt;
+    int ch;
+    int oldf;
+
+    tcgetattr(STDIN_FILENO, &oldt);
+
+    ch = getchar();
+    while(EOF == ch)
+    {
+        usleep(1);
+    }
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    fcntl(STDIN_FILENO, F_SETFL, oldf);
+
+    return ch;
+#endif
+}
+
 //
 
+//
+// Report Device info
 const char *hid_bus_name(hid_bus_type bus_type) {
 	static const char *const HidBusTypeName[] = {
 		"Unknown",
@@ -126,6 +159,175 @@ void print_devices_with_descriptor(struct hid_device_info *cur_dev) {
 	}
 }
 
+//
+// Default static testing
+void test_static()
+{
+    struct hid_device_info *devs;
+
+    devs = hid_enumerate(0x0, 0x0);
+    print_devices_with_descriptor(devs);
+    hid_free_enumeration(devs);
+}
+
+
+//
+// Fixed device testing
+void test_device()
+{
+    int res;
+    unsigned char buf[256];
+#define MAX_STR 255
+    wchar_t wstr[MAX_STR];
+    hid_device *handle;
+    int i;
+
+    // Set up the command buffer.
+    memset(buf,0x00,sizeof(buf));
+    buf[0] = 0x01;
+    buf[1] = 0x81;
+
+
+    // Open the device using the VID, PID,
+    // and optionally the Serial number.
+    ////handle = hid_open(0x4d8, 0x3f, L"12345");
+    handle = hid_open(0x4d8, 0x3f, NULL);
+    if (!handle) {
+        printf("unable to open device\n");
+        return;
+    }
+
+    // Read the Manufacturer String
+    wstr[0] = 0x0000;
+    res = hid_get_manufacturer_string(handle, wstr, MAX_STR);
+    if (res < 0)
+        printf("Unable to read manufacturer string\n");
+    printf("Manufacturer String: %ls\n", wstr);
+
+    // Read the Product String
+    wstr[0] = 0x0000;
+    res = hid_get_product_string(handle, wstr, MAX_STR);
+    if (res < 0)
+        printf("Unable to read product string\n");
+    printf("Product String: %ls\n", wstr);
+
+    // Read the Serial Number String
+    wstr[0] = 0x0000;
+    res = hid_get_serial_number_string(handle, wstr, MAX_STR);
+    if (res < 0)
+        printf("Unable to read serial number string\n");
+    printf("Serial Number String: (%d) %ls\n", wstr[0], wstr);
+
+    print_hid_report_descriptor_from_device(handle);
+
+    struct hid_device_info* info = hid_get_device_info(handle);
+    if (info == NULL) {
+        printf("Unable to get device info\n");
+    } else {
+        print_devices(info);
+    }
+
+    // Read Indexed String 1
+    wstr[0] = 0x0000;
+    res = hid_get_indexed_string(handle, 1, wstr, MAX_STR);
+    if (res < 0)
+        printf("Unable to read indexed string 1\n");
+    printf("Indexed String 1: %ls\n", wstr);
+
+    // Set the hid_read() function to be non-blocking.
+    hid_set_nonblocking(handle, 1);
+
+    // Try to read from the device. There should be no
+    // data here, but execution should not block.
+    res = hid_read(handle, buf, 17);
+
+    // Send a Feature Report to the device
+    buf[0] = 0x2;
+    buf[1] = 0xa0;
+    buf[2] = 0x0a;
+    buf[3] = 0x00;
+    buf[4] = 0x00;
+    res = hid_send_feature_report(handle, buf, 17);
+    if (res < 0) {
+        printf("Unable to send a feature report.\n");
+    }
+
+    memset(buf,0,sizeof(buf));
+
+    // Read a Feature Report from the device
+    buf[0] = 0x2;
+    res = hid_get_feature_report(handle, buf, sizeof(buf));
+    if (res < 0) {
+        printf("Unable to get a feature report: %ls\n", hid_error(handle));
+    }
+    else {
+        // Print out the returned buffer.
+        printf("Feature Report\n   ");
+        for (i = 0; i < res; i++)
+            printf("%02x ", (unsigned int) buf[i]);
+        printf("\n");
+    }
+
+    memset(buf,0,sizeof(buf));
+
+    // Toggle LED (cmd 0x80). The first byte is the report number (0x1).
+    buf[0] = 0x1;
+    buf[1] = 0x80;
+    res = hid_write(handle, buf, 17);
+    if (res < 0) {
+        printf("Unable to write(): %ls\n", hid_error(handle));
+    }
+
+
+    // Request state (cmd 0x81). The first byte is the report number (0x1).
+    buf[0] = 0x1;
+    buf[1] = 0x81;
+    hid_write(handle, buf, 17);
+    if (res < 0) {
+        printf("Unable to write()/2: %ls\n", hid_error(handle));
+    }
+
+    // Read requested state. hid_read() has been set to be
+    // non-blocking by the call to hid_set_nonblocking() above.
+    // This loop demonstrates the non-blocking nature of hid_read().
+    res = 0;
+    i = 0;
+    while (res == 0) {
+        res = hid_read(handle, buf, sizeof(buf));
+        if (res == 0) {
+            printf("waiting...\n");
+        }
+        if (res < 0) {
+            printf("Unable to read(): %ls\n", hid_error(handle));
+            break;
+        }
+
+        i++;
+        if (i >= 10) { /* 10 tries by 500 ms - 5 seconds of waiting*/
+            printf("read() timeout\n");
+            break;
+        }
+
+#ifdef _WIN32
+        Sleep(500);
+#else
+        usleep(500*1000);
+#endif
+    }
+
+    if (res > 0) {
+        printf("Data read:\n   ");
+        // Print out the returned buffer.
+        for (i = 0; i < res; i++)
+            printf("%02x ", (unsigned int) buf[i]);
+        printf("\n");
+    }
+
+    hid_close(handle);
+}
+
+//
+// Normal hotplug testing
 int device_callback(
 	hid_hotplug_callback_handle callback_handle,
 	struct hid_device_info* device,
@@ -146,6 +348,7 @@ int device_callback(
 	printf("  Release:      %hx\n", device->release_number);
 	printf("  Interface:    %d\n", device->interface_number);
 	printf("  Usage (page): 0x%hx (0x%hx)\n", device->usage, device->usage_page);
+    printf("(Press Q to exit the test)\n");
 	printf("\n");
 
 	/* Printed data might not show on the screen - force it out */
@@ -154,28 +357,162 @@ int device_callback(
 	return 0;
 }
 
+
+void test_hotplug()
+{
+    printf("Starting the Hotplug test\n");
+    printf("(Press Q to exit the test)\n");
+
+    hid_hotplug_callback_handle token1, token2;
+
+    hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token1);
+    hid_hotplug_register_callback(0x054c, 0x0ce6, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token2);
+
+    while (1)
+    {
+        int command = tolower(waitkey());
+        if ('q' == command)
+        {
+            break;
+        }
+    }
+
+    hid_hotplug_deregister_callback(token2);
+    hid_hotplug_deregister_callback(token1);
+
+    printf("\n\nHotplug test stopped\n");
+}
+
+//
+// Stress-testing weird edge cases in hotplugs
+int cb1_handle;
+int cb2_handle;
+int cb_test1_triggered;
+
+int cb2_func(hid_hotplug_callback_handle callback_handle,
+             struct hid_device_info *device,
+             hid_hotplug_event event,
+             void *user_data)
+{
+    (void) callback_handle;
+    (void) device;
+    (void) event;
+    (void) user_data;
+    // TIP: only perform the test once
+    if(cb_test1_triggered)
+    {
+        return 1;
+    }
+
+    printf("Callback 2 fired\n");
+
+    // Deregister the first callback
+    // It should be placed in the list at an index prior to the current one, which will make the pointer to the current one invalid on some implementations
+    hid_hotplug_deregister_callback(cb1_handle);
+
+    cb_test1_triggered = 1;
+
+    // As long as we are inside this callback, nothing goes wrong; however, returning from here will cause a use-after-free error on flawed implementations
+    // as to retrieve the next element (or to check for it's presence) it will look those dereference a pointer located in an already freed area
+    // Undefined behavior
+    return 1;
+}
+
+int cb1_func(hid_hotplug_callback_handle callback_handle,
+             struct hid_device_info *device,
+             hid_hotplug_event event,
+             void *user_data)
+{
+    (void) callback_handle;
+    (void) device;
+    (void) event;
+    (void) user_data;
+
+    // TIP: only perform the test once
+    if(cb_test1_triggered)
+    {
+        return 1;
+    }
+
+    printf("Callback 1 fired\n");
+
+    // Register the second callback and make it be called immediately by enumeration attempt
+    // Will cause a deadlock on Linux immediately
+    hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, cb2_func, NULL, &cb2_handle);
+    return 1;
+}
+
+void test_hotplug_deadlocks()
+{
+    cb_test1_triggered = 0;
+    printf("Starting the Hotplug callbacks deadlocks test\n");
+    printf("TIP: if you don't see a message that it succeeded, it means the test failed and the system is now deadlocked\n");
+    // Register the first callback and make it be called immediately by enumeration attempt (if at least 1 device is present)
+    hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, cb1_func, NULL, &cb1_handle);
+
+    printf("Test finished successfully (at least no deadlocks were found)\n");
+}
+
+
+//
+// CLI
+
+void print_version_check()
+{
+    printf("hidapi test/example tool. Compiled with hidapi version %s, runtime version %s.\n", HID_API_VERSION_STR, hid_version_str());
+    if (HID_API_VERSION == HID_API_MAKE_VERSION(hid_version()->major, hid_version()->minor, hid_version()->patch)) {
+        printf("Compile-time version matches runtime version of hidapi.\n\n");
+    }
+    else {
+        printf("Compile-time version is different than runtime version of hidapi.\n]n");
+    }
+}
+
+void interactive_loop()
+{
+    char command = 0;
+
+    print_version_check();
+
+    do {
+        printf("Interactive HIDAPI testing utility\n");
+        printf("    1: List connected devices\n");
+        printf("    2: Dynamic hotplug test\n");
+        printf("    3: Test specific device [04d8:003f]\n");
+        printf("    4: Test hotplug callback management deadlocking scenario\n");
+        printf("    q: Quit\n");
+        printf("Please enter command:");
+
+        command = tolower(waitkey());
+
+    // GET COMMAND
+        switch (command) {
+        case '1':
+            test_static();
+            break;
+        case '2':
+            test_hotplug();
+            break;
+        case '3':
+            test_device();
+            break;
+        case '4':
+            test_hotplug_deadlocks();
+        case 'q':
+            break;
+        default:
+            printf("Command not recognized\n");
+            break;
+        }
+    } while(command != 'q');
+}
+
+//
+// Main
 int main(int argc, char* argv[])
 {
 	(void)argc;
 	(void)argv;
-
-	int res;
-	unsigned char buf[256];
-	#define MAX_STR 255
-	wchar_t wstr[MAX_STR];
-	hid_device *handle;
-	int i;
-	hid_hotplug_callback_handle token1, token2;
-
-	struct hid_device_info *devs;
-
-	printf("hidapi test/example tool. Compiled with hidapi version %s, runtime version %s.\n", HID_API_VERSION_STR, hid_version_str());
-	if (HID_API_VERSION == HID_API_MAKE_VERSION(hid_version()->major, hid_version()->minor, hid_version()->patch)) {
-		printf("Compile-time version matches runtime version of hidapi.\n\n");
-	}
-	else {
-		printf("Compile-time version is different than runtime version of hidapi.\n]n");
-	}
 
 	if (hid_init())
 		return -1;
@@ -186,164 +523,7 @@ int main(int argc, char* argv[])
 	hid_darwin_set_open_exclusive(0);
 #endif
 
-	devs = hid_enumerate(0x0, 0x0);
-	print_devices_with_descriptor(devs);
-	hid_free_enumeration(devs);
-
-	hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token1);
-	hid_hotplug_register_callback(0x054c, 0x0ce6, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token2);
-
-	while (1)
-	{
-
-	}
-
-	hid_hotplug_deregister_callback(token2);
-	hid_hotplug_deregister_callback(token1);
-
-	// Set up the command buffer.
-	memset(buf,0x00,sizeof(buf));
-	buf[0] = 0x01;
-	buf[1] = 0x81;
-
-
-	// Open the device using the VID, PID,
-	// and optionally the Serial number.
-	////handle = hid_open(0x4d8, 0x3f, L"12345");
-	handle = hid_open(0x4d8, 0x3f, NULL);
-	if (!handle) {
-		printf("unable to open device\n");
-		hid_exit();
- 		return 1;
-	}
-
-	// Read the Manufacturer String
-	wstr[0] = 0x0000;
-	res = hid_get_manufacturer_string(handle, wstr, MAX_STR);
-	if (res < 0)
-		printf("Unable to read manufacturer string\n");
-	printf("Manufacturer String: %ls\n", wstr);
-
-	// Read the Product String
-	wstr[0] = 0x0000;
-	res = hid_get_product_string(handle, wstr, MAX_STR);
-	if (res < 0)
-		printf("Unable to read product string\n");
-	printf("Product String: %ls\n", wstr);
-
-	// Read the Serial Number String
-	wstr[0] = 0x0000;
-	res = hid_get_serial_number_string(handle, wstr, MAX_STR);
-	if (res < 0)
-		printf("Unable to read serial number string\n");
-	printf("Serial Number String: (%d) %ls\n", wstr[0], wstr);
-
-	print_hid_report_descriptor_from_device(handle);
-
-	struct hid_device_info* info = hid_get_device_info(handle);
-	if (info == NULL) {
-		printf("Unable to get device info\n");
-	} else {
-		print_devices(info);
-	}
-
-	// Read Indexed String 1
-	wstr[0] = 0x0000;
-	res = hid_get_indexed_string(handle, 1, wstr, MAX_STR);
-	if (res < 0)
-		printf("Unable to read indexed string 1\n");
-	printf("Indexed String 1: %ls\n", wstr);
-
-	// Set the hid_read() function to be non-blocking.
-	hid_set_nonblocking(handle, 1);
-
-	// Try to read from the device. There should be no
-	// data here, but execution should not block.
-	res = hid_read(handle, buf, 17);
-
-	// Send a Feature Report to the device
-	buf[0] = 0x2;
-	buf[1] = 0xa0;
-	buf[2] = 0x0a;
-	buf[3] = 0x00;
-	buf[4] = 0x00;
-	res = hid_send_feature_report(handle, buf, 17);
-	if (res < 0) {
-		printf("Unable to send a feature report.\n");
-	}
-
-	memset(buf,0,sizeof(buf));
-
-	// Read a Feature Report from the device
-	buf[0] = 0x2;
-	res = hid_get_feature_report(handle, buf, sizeof(buf));
-	if (res < 0) {
-		printf("Unable to get a feature report: %ls\n", hid_error(handle));
-	}
-	else {
-		// Print out the returned buffer.
-		printf("Feature Report\n   ");
-		for (i = 0; i < res; i++)
-			printf("%02x ", (unsigned int) buf[i]);
-		printf("\n");
-	}
-
-	memset(buf,0,sizeof(buf));
-
-	// Toggle LED (cmd 0x80). The first byte is the report number (0x1).
-	buf[0] = 0x1;
-	buf[1] = 0x80;
-	res = hid_write(handle, buf, 17);
-	if (res < 0) {
-		printf("Unable to write(): %ls\n", hid_error(handle));
-	}
-
-
-	// Request state (cmd 0x81). The first byte is the report number (0x1).
-	buf[0] = 0x1;
-	buf[1] = 0x81;
-	hid_write(handle, buf, 17);
-	if (res < 0) {
-		printf("Unable to write()/2: %ls\n", hid_error(handle));
-	}
-
-	// Read requested state. hid_read() has been set to be
-	// non-blocking by the call to hid_set_nonblocking() above.
-	// This loop demonstrates the non-blocking nature of hid_read().
-	res = 0;
-	i = 0;
-	while (res == 0) {
-		res = hid_read(handle, buf, sizeof(buf));
-		if (res == 0) {
-			printf("waiting...\n");
-		}
-		if (res < 0) {
-			printf("Unable to read(): %ls\n", hid_error(handle));
-			break;
-		}
-
-		i++;
-		if (i >= 10) { /* 10 tries by 500 ms - 5 seconds of waiting*/
-			printf("read() timeout\n");
-			break;
-		}
-
-#ifdef _WIN32
-		Sleep(500);
-#else
-		usleep(500*1000);
-#endif
-	}
-
-	if (res > 0) {
-		printf("Data read:\n   ");
-		// Print out the returned buffer.
-		for (i = 0; i < res; i++)
-			printf("%02x ", (unsigned int) buf[i]);
-		printf("\n");
-	}
-
-	hid_close(handle);
+    interactive_loop();
 
 	/* Free static HIDAPI objects. */
 	hid_exit();

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -66,6 +66,7 @@ int waitkey()
 #else
     struct termios oldt, newt;
     int ch;
+    int oldf;
 
     tcgetattr(STDIN_FILENO, &oldt);
     newt = oldt;

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -27,6 +27,7 @@
 	#include <windows.h>
     #include <conio.h>
 #else
+    #include <termios.h>
 	#include <unistd.h>
 #endif
 
@@ -470,7 +471,7 @@ void print_version_check()
 
 void interactive_loop()
 {
-    char command = 0;
+    int command = 0;
 
     print_version_check();
 

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -26,10 +26,10 @@
 // Headers needed for sleeping and console management (wait for a keypress)
 #ifdef _WIN32
 	#include <windows.h>
-    #include <conio.h>
+	#include <conio.h>
 #else
-    #include <fcntl.h>
-    #include <termios.h>
+	#include <fcntl.h>
+	#include <termios.h>
 	#include <unistd.h>
 #endif
 
@@ -63,29 +63,29 @@
 int waitkey()
 {
 #ifdef _WIN32
-    return _getch();
+	return _getch();
 #else
-    struct termios oldt, newt;
-    int ch;
-    int oldf;
+	struct termios oldt, newt;
+	int ch;
+	int oldf;
 
-    tcgetattr(STDIN_FILENO, &oldt);
-    newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
-    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-    oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
-    fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
+	tcgetattr(STDIN_FILENO, &oldt);
+	newt = oldt;
+	newt.c_lflag &= ~(ICANON | ECHO);
+	tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+	oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
+	fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
 
-    ch = getchar();
-    while(EOF == ch)
-    {
-        usleep(1);
-    }
+	ch = getchar();
+	while(EOF == ch)
+	{
+		usleep(1);
+	}
 
-    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    fcntl(STDIN_FILENO, F_SETFL, oldf);
+	tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+	fcntl(STDIN_FILENO, F_SETFL, oldf);
 
-    return ch;
+	return ch;
 #endif
 }
 
@@ -171,11 +171,11 @@ void print_devices_with_descriptor(struct hid_device_info *cur_dev) {
 // Default static testing
 void test_static()
 {
-    struct hid_device_info *devs;
+	struct hid_device_info *devs;
 
-    devs = hid_enumerate(0x0, 0x0);
-    print_devices_with_descriptor(devs);
-    hid_free_enumeration(devs);
+	devs = hid_enumerate(0x0, 0x0);
+	print_devices_with_descriptor(devs);
+	hid_free_enumeration(devs);
 }
 
 
@@ -183,155 +183,155 @@ void test_static()
 // Fixed device testing
 void test_device()
 {
-    int res;
-    unsigned char buf[256];
+	int res;
+	unsigned char buf[256];
 #define MAX_STR 255
-    wchar_t wstr[MAX_STR];
-    hid_device *handle;
-    int i;
+	wchar_t wstr[MAX_STR];
+	hid_device *handle;
+	int i;
 
-    // Set up the command buffer.
-    memset(buf,0x00,sizeof(buf));
-    buf[0] = 0x01;
-    buf[1] = 0x81;
-
-
-    // Open the device using the VID, PID,
-    // and optionally the Serial number.
-    ////handle = hid_open(0x4d8, 0x3f, L"12345");
-    handle = hid_open(0x4d8, 0x3f, NULL);
-    if (!handle) {
-        printf("unable to open device\n");
-        return;
-    }
-
-    // Read the Manufacturer String
-    wstr[0] = 0x0000;
-    res = hid_get_manufacturer_string(handle, wstr, MAX_STR);
-    if (res < 0)
-        printf("Unable to read manufacturer string\n");
-    printf("Manufacturer String: %ls\n", wstr);
-
-    // Read the Product String
-    wstr[0] = 0x0000;
-    res = hid_get_product_string(handle, wstr, MAX_STR);
-    if (res < 0)
-        printf("Unable to read product string\n");
-    printf("Product String: %ls\n", wstr);
-
-    // Read the Serial Number String
-    wstr[0] = 0x0000;
-    res = hid_get_serial_number_string(handle, wstr, MAX_STR);
-    if (res < 0)
-        printf("Unable to read serial number string\n");
-    printf("Serial Number String: (%d) %ls\n", wstr[0], wstr);
-
-    print_hid_report_descriptor_from_device(handle);
-
-    struct hid_device_info* info = hid_get_device_info(handle);
-    if (info == NULL) {
-        printf("Unable to get device info\n");
-    } else {
-        print_devices(info);
-    }
-
-    // Read Indexed String 1
-    wstr[0] = 0x0000;
-    res = hid_get_indexed_string(handle, 1, wstr, MAX_STR);
-    if (res < 0)
-        printf("Unable to read indexed string 1\n");
-    printf("Indexed String 1: %ls\n", wstr);
-
-    // Set the hid_read() function to be non-blocking.
-    hid_set_nonblocking(handle, 1);
-
-    // Try to read from the device. There should be no
-    // data here, but execution should not block.
-    res = hid_read(handle, buf, 17);
-
-    // Send a Feature Report to the device
-    buf[0] = 0x2;
-    buf[1] = 0xa0;
-    buf[2] = 0x0a;
-    buf[3] = 0x00;
-    buf[4] = 0x00;
-    res = hid_send_feature_report(handle, buf, 17);
-    if (res < 0) {
-        printf("Unable to send a feature report.\n");
-    }
-
-    memset(buf,0,sizeof(buf));
-
-    // Read a Feature Report from the device
-    buf[0] = 0x2;
-    res = hid_get_feature_report(handle, buf, sizeof(buf));
-    if (res < 0) {
-        printf("Unable to get a feature report: %ls\n", hid_error(handle));
-    }
-    else {
-        // Print out the returned buffer.
-        printf("Feature Report\n   ");
-        for (i = 0; i < res; i++)
-            printf("%02x ", (unsigned int) buf[i]);
-        printf("\n");
-    }
-
-    memset(buf,0,sizeof(buf));
-
-    // Toggle LED (cmd 0x80). The first byte is the report number (0x1).
-    buf[0] = 0x1;
-    buf[1] = 0x80;
-    res = hid_write(handle, buf, 17);
-    if (res < 0) {
-        printf("Unable to write(): %ls\n", hid_error(handle));
-    }
+	// Set up the command buffer.
+	memset(buf,0x00,sizeof(buf));
+	buf[0] = 0x01;
+	buf[1] = 0x81;
 
 
-    // Request state (cmd 0x81). The first byte is the report number (0x1).
-    buf[0] = 0x1;
-    buf[1] = 0x81;
-    hid_write(handle, buf, 17);
-    if (res < 0) {
-        printf("Unable to write()/2: %ls\n", hid_error(handle));
-    }
+	// Open the device using the VID, PID,
+	// and optionally the Serial number.
+	////handle = hid_open(0x4d8, 0x3f, L"12345");
+	handle = hid_open(0x4d8, 0x3f, NULL);
+	if (!handle) {
+		printf("unable to open device\n");
+		return;
+	}
 
-    // Read requested state. hid_read() has been set to be
-    // non-blocking by the call to hid_set_nonblocking() above.
-    // This loop demonstrates the non-blocking nature of hid_read().
-    res = 0;
-    i = 0;
-    while (res == 0) {
-        res = hid_read(handle, buf, sizeof(buf));
-        if (res == 0) {
-            printf("waiting...\n");
-        }
-        if (res < 0) {
-            printf("Unable to read(): %ls\n", hid_error(handle));
-            break;
-        }
+	// Read the Manufacturer String
+	wstr[0] = 0x0000;
+	res = hid_get_manufacturer_string(handle, wstr, MAX_STR);
+	if (res < 0)
+		printf("Unable to read manufacturer string\n");
+	printf("Manufacturer String: %ls\n", wstr);
 
-        i++;
-        if (i >= 10) { /* 10 tries by 500 ms - 5 seconds of waiting*/
-            printf("read() timeout\n");
-            break;
-        }
+	// Read the Product String
+	wstr[0] = 0x0000;
+	res = hid_get_product_string(handle, wstr, MAX_STR);
+	if (res < 0)
+		printf("Unable to read product string\n");
+	printf("Product String: %ls\n", wstr);
+
+	// Read the Serial Number String
+	wstr[0] = 0x0000;
+	res = hid_get_serial_number_string(handle, wstr, MAX_STR);
+	if (res < 0)
+		printf("Unable to read serial number string\n");
+	printf("Serial Number String: (%d) %ls\n", wstr[0], wstr);
+
+	print_hid_report_descriptor_from_device(handle);
+
+	struct hid_device_info* info = hid_get_device_info(handle);
+	if (info == NULL) {
+		printf("Unable to get device info\n");
+	} else {
+		print_devices(info);
+	}
+
+	// Read Indexed String 1
+	wstr[0] = 0x0000;
+	res = hid_get_indexed_string(handle, 1, wstr, MAX_STR);
+	if (res < 0)
+		printf("Unable to read indexed string 1\n");
+	printf("Indexed String 1: %ls\n", wstr);
+
+	// Set the hid_read() function to be non-blocking.
+	hid_set_nonblocking(handle, 1);
+
+	// Try to read from the device. There should be no
+	// data here, but execution should not block.
+	res = hid_read(handle, buf, 17);
+
+	// Send a Feature Report to the device
+	buf[0] = 0x2;
+	buf[1] = 0xa0;
+	buf[2] = 0x0a;
+	buf[3] = 0x00;
+	buf[4] = 0x00;
+	res = hid_send_feature_report(handle, buf, 17);
+	if (res < 0) {
+		printf("Unable to send a feature report.\n");
+	}
+
+	memset(buf,0,sizeof(buf));
+
+	// Read a Feature Report from the device
+	buf[0] = 0x2;
+	res = hid_get_feature_report(handle, buf, sizeof(buf));
+	if (res < 0) {
+		printf("Unable to get a feature report: %ls\n", hid_error(handle));
+	}
+	else {
+		// Print out the returned buffer.
+		printf("Feature Report\n   ");
+		for (i = 0; i < res; i++)
+			printf("%02x ", (unsigned int) buf[i]);
+		printf("\n");
+	}
+
+	memset(buf,0,sizeof(buf));
+
+	// Toggle LED (cmd 0x80). The first byte is the report number (0x1).
+	buf[0] = 0x1;
+	buf[1] = 0x80;
+	res = hid_write(handle, buf, 17);
+	if (res < 0) {
+		printf("Unable to write(): %ls\n", hid_error(handle));
+	}
+
+
+	// Request state (cmd 0x81). The first byte is the report number (0x1).
+	buf[0] = 0x1;
+	buf[1] = 0x81;
+	hid_write(handle, buf, 17);
+	if (res < 0) {
+		printf("Unable to write()/2: %ls\n", hid_error(handle));
+	}
+
+	// Read requested state. hid_read() has been set to be
+	// non-blocking by the call to hid_set_nonblocking() above.
+	// This loop demonstrates the non-blocking nature of hid_read().
+	res = 0;
+	i = 0;
+	while (res == 0) {
+		res = hid_read(handle, buf, sizeof(buf));
+		if (res == 0) {
+			printf("waiting...\n");
+		}
+		if (res < 0) {
+			printf("Unable to read(): %ls\n", hid_error(handle));
+			break;
+		}
+
+		i++;
+		if (i >= 10) { /* 10 tries by 500 ms - 5 seconds of waiting*/
+			printf("read() timeout\n");
+			break;
+		}
 
 #ifdef _WIN32
-        Sleep(500);
+		Sleep(500);
 #else
-        usleep(500*1000);
+		usleep(500*1000);
 #endif
-    }
+	}
 
-    if (res > 0) {
-        printf("Data read:\n   ");
-        // Print out the returned buffer.
-        for (i = 0; i < res; i++)
-            printf("%02x ", (unsigned int) buf[i]);
-        printf("\n");
-    }
+	if (res > 0) {
+		printf("Data read:\n   ");
+		// Print out the returned buffer.
+		for (i = 0; i < res; i++)
+			printf("%02x ", (unsigned int) buf[i]);
+		printf("\n");
+	}
 
-    hid_close(handle);
+	hid_close(handle);
 }
 
 //
@@ -356,7 +356,7 @@ int device_callback(
 	printf("  Release:      %hx\n", device->release_number);
 	printf("  Interface:    %d\n", device->interface_number);
 	printf("  Usage (page): 0x%hx (0x%hx)\n", device->usage, device->usage_page);
-    printf("(Press Q to exit the test)\n");
+	printf("(Press Q to exit the test)\n");
 	printf("\n");
 
 	/* Printed data might not show on the screen - force it out */
@@ -368,27 +368,27 @@ int device_callback(
 
 void test_hotplug()
 {
-    printf("Starting the Hotplug test\n");
-    printf("(Press Q to exit the test)\n");
+	printf("Starting the Hotplug test\n");
+	printf("(Press Q to exit the test)\n");
 
-    hid_hotplug_callback_handle token1, token2;
+	hid_hotplug_callback_handle token1, token2;
 
-    hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token1);
-    hid_hotplug_register_callback(0x054c, 0x0ce6, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token2);
+	hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token1);
+	hid_hotplug_register_callback(0x054c, 0x0ce6, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, device_callback, NULL, &token2);
 
-    while (1)
-    {
-        int command = tolower(waitkey());
-        if ('q' == command)
-        {
-            break;
-        }
-    }
+	while (1)
+	{
+		int command = tolower(waitkey());
+		if ('q' == command)
+		{
+			break;
+		}
+	}
 
-    hid_hotplug_deregister_callback(token2);
-    hid_hotplug_deregister_callback(token1);
+	hid_hotplug_deregister_callback(token2);
+	hid_hotplug_deregister_callback(token1);
 
-    printf("\n\nHotplug test stopped\n");
+	printf("\n\nHotplug test stopped\n");
 }
 
 //
@@ -402,28 +402,28 @@ int cb2_func(hid_hotplug_callback_handle callback_handle,
              hid_hotplug_event event,
              void *user_data)
 {
-    (void) callback_handle;
-    (void) device;
-    (void) event;
-    (void) user_data;
-    // TIP: only perform the test once
-    if(cb_test1_triggered)
-    {
-        return 1;
-    }
+	(void) callback_handle;
+	(void) device;
+	(void) event;
+	(void) user_data;
+	// TIP: only perform the test once
+	if(cb_test1_triggered)
+	{
+		return 1;
+	}
 
-    printf("Callback 2 fired\n");
+	printf("Callback 2 fired\n");
 
-    // Deregister the first callback
-    // It should be placed in the list at an index prior to the current one, which will make the pointer to the current one invalid on some implementations
-    hid_hotplug_deregister_callback(cb1_handle);
+	// Deregister the first callback
+	// It should be placed in the list at an index prior to the current one, which will make the pointer to the current one invalid on some implementations
+	hid_hotplug_deregister_callback(cb1_handle);
 
-    cb_test1_triggered = 1;
+	cb_test1_triggered = 1;
 
-    // As long as we are inside this callback, nothing goes wrong; however, returning from here will cause a use-after-free error on flawed implementations
-    // as to retrieve the next element (or to check for it's presence) it will look those dereference a pointer located in an already freed area
-    // Undefined behavior
-    return 1;
+	// As long as we are inside this callback, nothing goes wrong; however, returning from here will cause a use-after-free error on flawed implementations
+	// as to retrieve the next element (or to check for it's presence) it will look those dereference a pointer located in an already freed area
+	// Undefined behavior
+	return 1;
 }
 
 int cb1_func(hid_hotplug_callback_handle callback_handle,
@@ -431,34 +431,34 @@ int cb1_func(hid_hotplug_callback_handle callback_handle,
              hid_hotplug_event event,
              void *user_data)
 {
-    (void) callback_handle;
-    (void) device;
-    (void) event;
-    (void) user_data;
+	(void) callback_handle;
+	(void) device;
+	(void) event;
+	(void) user_data;
 
-    // TIP: only perform the test once
-    if(cb_test1_triggered)
-    {
-        return 1;
-    }
+	// TIP: only perform the test once
+	if(cb_test1_triggered)
+	{
+		return 1;
+	}
 
-    printf("Callback 1 fired\n");
+	printf("Callback 1 fired\n");
 
-    // Register the second callback and make it be called immediately by enumeration attempt
-    // Will cause a deadlock on Linux immediately
-    hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, cb2_func, NULL, &cb2_handle);
-    return 1;
+	// Register the second callback and make it be called immediately by enumeration attempt
+	// Will cause a deadlock on Linux immediately
+	hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, cb2_func, NULL, &cb2_handle);
+	return 1;
 }
 
 void test_hotplug_deadlocks()
 {
-    cb_test1_triggered = 0;
-    printf("Starting the Hotplug callbacks deadlocks test\n");
-    printf("TIP: if you don't see a message that it succeeded, it means the test failed and the system is now deadlocked\n");
-    // Register the first callback and make it be called immediately by enumeration attempt (if at least 1 device is present)
-    hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, cb1_func, NULL, &cb1_handle);
+	cb_test1_triggered = 0;
+	printf("Starting the Hotplug callbacks deadlocks test\n");
+	printf("TIP: if you don't see a message that it succeeded, it means the test failed and the system is now deadlocked\n");
+	// Register the first callback and make it be called immediately by enumeration attempt (if at least 1 device is present)
+	hid_hotplug_register_callback(0, 0, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT, HID_API_HOTPLUG_ENUMERATE, cb1_func, NULL, &cb1_handle);
 
-    printf("Test finished successfully (at least no deadlocks were found)\n");
+	printf("Test finished successfully (at least no deadlocks were found)\n");
 }
 
 
@@ -467,52 +467,55 @@ void test_hotplug_deadlocks()
 
 void print_version_check()
 {
-    printf("hidapi test/example tool. Compiled with hidapi version %s, runtime version %s.\n", HID_API_VERSION_STR, hid_version_str());
-    if (HID_API_VERSION == HID_API_MAKE_VERSION(hid_version()->major, hid_version()->minor, hid_version()->patch)) {
-        printf("Compile-time version matches runtime version of hidapi.\n\n");
-    }
-    else {
-        printf("Compile-time version is different than runtime version of hidapi.\n]n");
-    }
+	printf("hidapi test/example tool. Compiled with hidapi version %s, runtime version %s.\n", HID_API_VERSION_STR, hid_version_str());
+	if (HID_API_VERSION == HID_API_MAKE_VERSION(hid_version()->major, hid_version()->minor, hid_version()->patch)) {
+		printf("Compile-time version matches runtime version of hidapi.\n\n");
+	}
+	else {
+		printf("Compile-time version is different than runtime version of hidapi.\n]n");
+	}
 }
 
 void interactive_loop()
 {
-    int command = 0;
+	int command = 0;
 
-    print_version_check();
+	print_version_check();
 
-    do {
-        printf("Interactive HIDAPI testing utility\n");
-        printf("    1: List connected devices\n");
-        printf("    2: Dynamic hotplug test\n");
-        printf("    3: Test specific device [04d8:003f]\n");
-        printf("    4: Test hotplug callback management deadlocking scenario\n");
-        printf("    q: Quit\n");
-        printf("Please enter command:");
+	do {
+		printf("Interactive HIDAPI testing utility\n");
+		printf("    1: List connected devices\n");
+		printf("    2: Dynamic hotplug test\n");
+		printf("    3: Test specific device [04d8:003f]\n");
+		printf("    4: Test hotplug callback management deadlocking scenario\n");
+		printf("    q: Quit\n");
+		printf("Please enter command:");
 
-        command = tolower(waitkey());
+		command = tolower(waitkey());
 
-    // GET COMMAND
-        switch (command) {
-        case '1':
-            test_static();
-            break;
-        case '2':
-            test_hotplug();
-            break;
-        case '3':
-            test_device();
-            break;
-        case '4':
-            test_hotplug_deadlocks();
-        case 'q':
-            break;
-        default:
-            printf("Command not recognized\n");
-            break;
-        }
-    } while(command != 'q');
+		printf("\n\n========================================\n\n");
+
+	// GET COMMAND
+		switch (command) {
+		case '1':
+			test_static();
+			break;
+		case '2':
+			test_hotplug();
+			break;
+		case '3':
+			test_device();
+			break;
+		case '4':
+			test_hotplug_deadlocks();
+		case 'q':
+			break;
+		default:
+			printf("Command not recognized\n");
+			break;
+		}
+		printf("\n\n========================================\n\n");
+	} while(command != 'q');
 }
 
 //
@@ -531,14 +534,10 @@ int main(int argc, char* argv[])
 	hid_darwin_set_open_exclusive(0);
 #endif
 
-    interactive_loop();
+	interactive_loop();
 
 	/* Free static HIDAPI objects. */
 	hid_exit();
-
-#ifdef _WIN32
-	system("pause");
-#endif
 
 	return 0;
 }

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -66,9 +66,13 @@ int waitkey()
 #else
     struct termios oldt, newt;
     int ch;
-    int oldf;
 
     tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+    oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
+    fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
 
     ch = getchar();
     while(EOF == ch)

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -19,6 +19,7 @@
 #include <wchar.h>
 #include <string.h>
 #include <stdlib.h>
+#include <ctype.h> // for "tolower()"
 
 #include <hidapi.h>
 

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -360,9 +360,6 @@ int device_callback(
 	printf("(Press Q to exit the test)\n");
 	printf("\n");
 
-	/* Printed data might not show on the screen - force it out */
-	fflush(stdout);
-
 	return 0;
 }
 
@@ -489,12 +486,13 @@ void interactive_loop()
 		printf("    2: Dynamic hotplug test\n");
 		printf("    3: Test specific device [04d8:003f]\n");
 		printf("    4: Test hotplug callback management deadlocking scenario\n");
-		printf("    q: Quit\n");
+		printf("    Q: Quit\n");
 		printf("Please enter command:");
 
-		command = tolower(waitkey());
+		command = toupper(waitkey());
 
-		printf("\n\n========================================\n\n");
+		printf("%c\n\n========================================\n\n", command);
+		fflush(stdout);
 
 	// GET COMMAND
 		switch (command) {
@@ -509,12 +507,16 @@ void interactive_loop()
 			break;
 		case '4':
 			test_hotplug_deadlocks();
-		case 'q':
+		case 'Q':
 			break;
 		default:
 			printf("Command not recognized\n");
 			break;
 		}
+
+		/* Printed data might not show on the screen when the command is done - force it out */
+		fflush(stdout);
+
 		printf("\n\n========================================\n\n");
 	} while(command != 'q');
 }

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -170,7 +170,7 @@ void print_devices_with_descriptor(struct hid_device_info *cur_dev) {
 
 //
 // Default static testing
-void test_static()
+void test_static(void)
 {
 	struct hid_device_info *devs;
 
@@ -182,7 +182,7 @@ void test_static()
 
 //
 // Fixed device testing
-void test_device()
+void test_device(void)
 {
 	int res;
 	unsigned char buf[256];
@@ -364,7 +364,7 @@ int device_callback(
 }
 
 
-void test_hotplug()
+void test_hotplug(void)
 {
 	printf("Starting the Hotplug test\n");
 	printf("(Press Q to exit the test)\n");

--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -489,10 +489,12 @@ void interactive_loop(void)
 		printf("    Q: Quit\n");
 		printf("Please enter command:");
 
+		/* Printed data might not show on the screen when the command is done - force it out */
+		fflush(stdout);
+
 		command = toupper(waitkey());
 
 		printf("%c\n\n========================================\n\n", command);
-		fflush(stdout);
 
 	// GET COMMAND
 		switch (command) {
@@ -518,7 +520,7 @@ void interactive_loop(void)
 		fflush(stdout);
 
 		printf("\n\n========================================\n\n");
-	} while(command != 'q');
+	} while(command != 'Q');
 }
 
 //

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -162,10 +162,10 @@ static struct hid_hotplug_context {
 	/* This mutex prevents changes to the callback list */
 	pthread_mutex_t mutex;
 
-	/* Boolean flags are set to only use 1 bit each */
-	int mutex_ready;
-	int mutex_in_use;
-	int cb_list_dirty;
+	/* Boolean flags */
+	unsigned char mutex_ready : 1;
+	unsigned char mutex_in_use : 1;
+	unsigned char cb_list_dirty : 1;
 
 	struct hid_hotplug_queue* queue;
 

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1320,7 +1320,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the mutex as IN USE, to prevent callback removal from inside a callback */
-	int was_in_use = (2 == hid_hotplug_context.mutex_state);
+	int old_state = hid_hotplug_context.mutex_state;
 	hid_hotplug_context.mutex_state = 2;
 	
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
@@ -1335,9 +1335,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 		}
 	}
 
-	if (!was_in_use) {
-		hid_hotplug_context.mutex_state = 1;
-	}
+	hid_hotplug_context.mutex_state = old_state;
 	pthread_mutex_unlock(&hid_hotplug_context.cb_mutex);
 
 	return 0;

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -163,9 +163,9 @@ static struct hid_hotplug_context {
 	pthread_mutex_t mutex;
 
 	/* Boolean flags */
-	unsigned char mutex_ready : 1;
-	unsigned char mutex_in_use : 1;
-	unsigned char cb_list_dirty : 1;
+	unsigned char mutex_ready;
+	unsigned char mutex_in_use;
+	unsigned char cb_list_dirty;
 
 	struct hid_hotplug_queue* queue;
 

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1344,8 +1344,6 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 
 int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_callback_handle callback_handle)
 {
-	struct hid_hotplug_callback *hotplug_cb = NULL;
-
 	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG) || !hid_hotplug_context.mutex_state || callback_handle <= 0) {
 		return -1;
 	}
@@ -1356,6 +1354,8 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 		pthread_mutex_unlock(&hid_hotplug_context.mutex);
 		return -1;
 	}
+
+	int result = -1;
 
 	/* Remove this notification */
 	for (struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs; *current != NULL; current = &(*current)->next) {
@@ -1377,7 +1377,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 
 	pthread_mutex_unlock(&hid_hotplug_context.mutex);
 
-	return 0;
+	return result;
 }
 
 hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -570,7 +570,15 @@ static void hid_internal_hotplug_init()
 	if (!hid_hotplug_context.mutex_state) {
 		hidapi_thread_state_init(&hid_hotplug_context.libusb_thread);
 		hidapi_thread_state_init(&hid_hotplug_context.callback_thread);
-		pthread_mutex_init(&hid_hotplug_context.cb_mutex, NULL);
+
+		/* Initialize the mutex as recursive */
+		pthread_mutexattr_t attr;
+		pthread_mutexattr_init(&attr);
+		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+		pthread_mutex_init(&hid_hotplug_context.mutex, &attr);
+		pthread_mutexattr_destroy(&attr);
+
+		/* Set state to Ready */
 		hid_hotplug_context.mutex_state = 1;
 	}
 }

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -165,7 +165,7 @@ static struct hid_hotplug_context {
 	/* Boolean flags */
 	unsigned char mutex_ready : 1;
 	unsigned char mutex_in_use : 1;
-	unsigned char cb_list_dirty : 1=;
+	unsigned char cb_list_dirty : 1;
 
 	struct hid_hotplug_queue* queue;
 
@@ -1363,7 +1363,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the mutex as IN USE, to prevent callback removal from inside a callback */
-	int old_state = hid_hotplug_context.mutex_in_use;
+	unsigned char old_state = hid_hotplug_context.mutex_in_use;
 	hid_hotplug_context.mutex_in_use = 1;
 	
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -556,13 +556,6 @@ static void hid_internal_hotplug_cleanup()
 	/* Wait for both threads to stop */
 	hidapi_thread_join(&hid_hotplug_context.libusb_thread);
 	hidapi_thread_join(&hid_hotplug_context.callback_thread);
-
-	/* Cleanup connected device list */
-	hid_free_enumeration(hid_hotplug_context.devs);
-	hid_hotplug_context.devs = NULL;
-	/* Disarm the libusb listener */
-	libusb_hotplug_deregister_callback(usb_context, hid_hotplug_context.callback_handle);
-	libusb_exit(hid_hotplug_context.context);
 }
 
 static void hid_internal_hotplug_init()
@@ -1230,6 +1223,14 @@ static void* callback_thread(void* user_data)
 		/* Make the tread fall asleep and wait for a condition to wake it up */
 		hidapi_thread_cond_timedwait(&hid_hotplug_context.callback_thread, &ts);
 	}
+
+	/* Cleanup connected device list */
+	hid_free_enumeration(hid_hotplug_context.devs);
+	hid_hotplug_context.devs = NULL;
+	/* Disarm the libusb listener */
+	libusb_hotplug_deregister_callback(usb_context, hid_hotplug_context.callback_handle);
+	libusb_exit(hid_hotplug_context.context);
+
 	hidapi_thread_mutex_unlock(&hid_hotplug_context.callback_thread);
 
 	return NULL;

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -163,9 +163,9 @@ static struct hid_hotplug_context {
 	pthread_mutex_t mutex;
 
 	/* Boolean flags are set to only use 1 bit each */
-	int mutex_ready : 1;
-	int mutex_in_use : 1;
-	int cb_list_dirty : 1;
+	int mutex_ready;
+	int mutex_in_use;
+	int cb_list_dirty;
 
 	struct hid_hotplug_queue* queue;
 

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1096,6 +1096,7 @@ static void hid_internal_invoke_callbacks(struct hid_device_info* info, hid_hotp
 		}
 		current = &callback->next;
 	}
+
 	hid_hotplug_context.mutex_state = 1;
 	pthread_mutex_unlock(&hid_hotplug_context.cb_mutex);
 }

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -165,7 +165,7 @@ static struct hid_hotplug_context {
 	/* Boolean flags */
 	unsigned char mutex_ready : 1;
 	unsigned char mutex_in_use : 1;
-	unsigned char cb_list_dirty : 1;
+	unsigned char cb_list_dirty : 1=;
 
 	struct hid_hotplug_queue* queue;
 
@@ -1228,7 +1228,7 @@ static void* callback_thread(void* user_data)
 		/* We use this thread's mutex to protect the queue */
 		hidapi_thread_mutex_lock(&hid_hotplug_context.libusb_thread);
 		while (hid_hotplug_context.queue) {
-			hid_hotplug_event* cur_event = hid_hotplug_context.queue;
+			struct hid_hotplug_queue *cur_event = hid_hotplug_context.queue;
 			process_hotplug_event(cur_event);
 
 			/* Empty the queue */

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1325,7 +1325,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the mutex as IN USE, to prevent callback removal from inside a callback */
-	int was_in_use = (2 == hid_hotplug_context.mutex_state);
+	int old_state = hid_hotplug_context.mutex_state;
 	hid_hotplug_context.mutex_state = 2;
 	
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
@@ -1340,9 +1340,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 		}
 	}
 
-	if (!was_in_use) {
-		hid_hotplug_context.mutex_state = 1;
-	}
+	hid_hotplug_context.mutex_state = old_state;
 	pthread_mutex_unlock(&hid_hotplug_context.mutex);
 	
 	return 0;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1220,7 +1220,7 @@ static void* hotplug_thread(void* user_data)
 				udev_device_unref(raw_dev);
 
 				/* Traverse the list of callbacks and check if any were marked for removal */
-				struct hid_device_info **current = &hid_hotplug_context.hotplug_cbs;
+				struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
 				while (*current) {
 					struct hid_hotplug_callback *callback = *current;
 					if (!callback->events) {

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -901,9 +901,9 @@ static struct hid_hotplug_context {
 	pthread_mutex_t mutex;
 
 	/* Boolean flags */
-	unsigned char mutex_ready : 1;
-	unsigned char mutex_in_use : 1;
-	unsigned char cb_list_dirty : 1;
+	unsigned char mutex_ready;
+	unsigned char mutex_in_use;
+	unsigned char cb_list_dirty;
 
 	/* HIDAPI unique callback handle counter */
 	hid_hotplug_callback_handle next_handle;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1111,6 +1111,7 @@ void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
 static void hid_internal_invoke_callbacks(struct hid_device_info *info, hid_hotplug_event event)
 {
 	hid_hotplug_context.mutex_state = 2;
+
 	struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
 	while (*current) {
 		struct hid_hotplug_callback *callback = *current;
@@ -1126,6 +1127,7 @@ static void hid_internal_invoke_callbacks(struct hid_device_info *info, hid_hotp
 		}
 		current = &callback->next;
 	}
+
 	hid_hotplug_context.mutex_state = 1;
 }
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -934,7 +934,7 @@ struct hid_hotplug_callback {
 
 static void hid_internal_hotplug_cleanup()
 {
-	if (hid_hotplug_context.hotplug_cbs != NULL) {
+	if (hid_hotplug_context.hotplug_cbs != NULL || hid_hotplug_context.mutex_state != 1) {
 		return;
 	}
 
@@ -1303,8 +1303,8 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 		pthread_create(&hid_hotplug_context.thread, NULL, &hotplug_thread, NULL);
 	}
 
-	/* Mark the critical section as IN USE, to prevent callback removal from inside a callback */
-	int was_in_use = (2 == hid_hotplug_context.critical_section_state);
+	/* Mark the mutex as IN USE, to prevent callback removal from inside a callback */
+	int was_in_use = (2 == hid_hotplug_context.mutex_state);
 	hid_hotplug_context.mutex_state = 2;
 	
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -942,7 +942,7 @@ static void hid_internal_hotplug_remove_postponed()
 	if (!hid_hotplug_context.mutex_ready || hid_hotplug_context.mutex_in_use || !hid_hotplug_context.cb_list_dirty) {
 		return;
 	}
-	
+
 	/* Traverse the list of callbacks and check if any were marked for removal */
 	struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
 	while (*current) {
@@ -965,6 +965,7 @@ static void hid_internal_hotplug_cleanup()
 		return;
 	}
 
+	/* Before checking if the list is empty, clear any entries whose removal was postponed first */
 	hid_internal_hotplug_remove_postponed();
 
 	if (hid_hotplug_context.hotplug_cbs != NULL) {

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -901,9 +901,9 @@ static struct hid_hotplug_context {
 	pthread_mutex_t mutex;
 
 	/* Boolean flags are set to only use 1 bit each */
-	int mutex_ready : 1;
-	int mutex_in_use : 1;
-	int cb_list_dirty : 1;
+	int mutex_ready;
+	int mutex_in_use;
+	int cb_list_dirty;
 
 	/* HIDAPI unique callback handle counter */
 	hid_hotplug_callback_handle next_handle;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1220,7 +1220,7 @@ static void* hotplug_thread(void* user_data)
 				udev_device_unref(raw_dev);
 
 				/* Traverse the list of callbacks and check if any were marked for removal */
-				current = &hid_hotplug_context.hotplug_cbs;
+				struct hid_device_info **current = &hid_hotplug_context.hotplug_cbs;
 				while (*current) {
 					struct hid_hotplug_callback *callback = *current;
 					if (!callback->events) {

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -1352,7 +1352,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the mutex as IN USE, to prevent callback removal from inside a callback */
-	int old_state = hid_hotplug_context.mutex_in_use;
+	unsigned char old_state = hid_hotplug_context.mutex_in_use;
 	hid_hotplug_context.mutex_in_use = 1;
 	
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -900,10 +900,10 @@ static struct hid_hotplug_context {
 
 	pthread_mutex_t mutex;
 
-	/* Boolean flags are set to only use 1 bit each */
-	int mutex_ready;
-	int mutex_in_use;
-	int cb_list_dirty;
+	/* Boolean flags */
+	unsigned char mutex_ready : 1;
+	unsigned char mutex_in_use : 1;
+	unsigned char cb_list_dirty : 1;
 
 	/* HIDAPI unique callback handle counter */
 	hid_hotplug_callback_handle next_handle;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -519,7 +519,7 @@ static struct hid_hotplug_context {
 	.devs = NULL
 };
 
-static void hid_internal_hotplug_remove_postponed()
+static void hid_internal_hotplug_remove_postponed(void)
 {
 	/* Unregister the callbacks whose removal was postponed */
 	/* This function is always called inside a locked mutex */
@@ -544,7 +544,7 @@ static void hid_internal_hotplug_remove_postponed()
 	hid_hotplug_context.cb_list_dirty = 0;
 }
 
-static void hid_internal_hotplug_cleanup()
+static void hid_internal_hotplug_cleanup(void)
 {
 	if (!hid_hotplug_context.mutex_ready || hid_hotplug_context.mutex_in_use) {
 		return;
@@ -572,7 +572,7 @@ static void hid_internal_hotplug_cleanup()
 	pthread_join(hid_hotplug_context.thread, NULL);
 }
 
-static void hid_internal_hotplug_init()
+static void hid_internal_hotplug_init(void)
 {
 	if (!hid_hotplug_context.mutex_ready) {
 		/* Initialize the mutex as recursive */
@@ -589,7 +589,7 @@ static void hid_internal_hotplug_init()
 	}
 }
 
-static void hid_internal_hotplug_exit()
+static void hid_internal_hotplug_exit(void)
 {
 	if (!hid_hotplug_context.mutex_ready) {
 		return;
@@ -648,7 +648,8 @@ static int hid_internal_match_device_id(unsigned short vendor_id, unsigned short
 	return (expected_vendor_id == 0x0 || vendor_id == expected_vendor_id) && (expected_product_id == 0x0 || product_id == expected_product_id);
 }
 
-static void process_pending_events(void) {
+static void process_pending_events(void)
+{
 	SInt32 res;
 	do {
 		res = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, FALSE);
@@ -1086,8 +1087,9 @@ static void hid_internal_hotplug_disconnect_callback(void *context, IOReturn res
 	}
 }
 
-static void hotplug_stop_callback(void *context)
+static void hotplug_stop_callback(void* context)
 {
+	(void) context;
 	CFRunLoopStop(hid_hotplug_context.run_loop);
 }
 

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -498,9 +498,9 @@ static struct hid_hotplug_context {
 	pthread_mutex_t mutex;
 
 	/* Boolean flags */
-	unsigned char mutex_ready : 1;
-	unsigned char mutex_in_use : 1;
-	unsigned char cb_list_dirty : 1;
+	unsigned char mutex_ready;
+	unsigned char mutex_in_use;
+	unsigned char cb_list_dirty;
 
 	/* Linked list of the hotplug callbacks */
 	struct hid_hotplug_callback *hotplug_cbs;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1088,8 +1088,7 @@ static void hid_internal_hotplug_disconnect_callback(void *context, IOReturn res
 
 static void hotplug_stop_callback(void *context)
 {
-	hid_device *dev = (hid_device*) context;
-	CFRunLoopStop(dev->run_loop); /*TODO: CFRunLoopGetCurrent()*/
+	CFRunLoopStop(hid_hotplug_context.run_loop);
 }
 
 static void* hotplug_thread(void* user_data)
@@ -1110,7 +1109,7 @@ static void* hotplug_thread(void* user_data)
 	hid_hotplug_context.run_loop = CFRunLoopGetCurrent();
 	
 	/* Create the RunLoopSource which is used to signal the
-	   event loop to stop when hid_close() is called. */
+	   event loop to stop when hid_internal_hotplug_cleanup() is called. */
 	CFRunLoopSourceContext ctx;
 	memset(&ctx, 0, sizeof(ctx));
 	ctx.version = 0;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1188,7 +1188,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the mutex as IN USE, to prevent callback removal from inside a callback */
-	int was_in_use = (2 == hid_hotplug_context.mutex_state);
+	int old_state = hid_hotplug_context.mutex_state;
 	hid_hotplug_context.mutex_state = 2;
 
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
@@ -1202,10 +1202,8 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 			device = device->next;
 		}
 	}
-	
-	if (!was_in_use) {
-		hid_hotplug_context.mutex_state = 1;
-	}
+
+	hid_hotplug_context.mutex_state = old_state;
 	pthread_mutex_unlock(&hid_hotplug_context.mutex);
 
 	return 0;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1229,7 +1229,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the mutex as IN USE, to prevent callback removal from inside a callback */
-	int old_state = hid_hotplug_context.mutex_in_use;
+	unsigned char old_state = hid_hotplug_context.mutex_in_use;
 	hid_hotplug_context.mutex_in_use = 1;
 
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -498,9 +498,9 @@ static struct hid_hotplug_context {
 	pthread_mutex_t mutex;
 
 	/* Boolean flags are set to only use 1 bit each */
-	int mutex_ready : 1;
-	int mutex_in_use : 1;
-	int cb_list_dirty : 1;
+	int mutex_ready;
+	int mutex_in_use;
+	int cb_list_dirty;
 
 	/* Linked list of the hotplug callbacks */
 	struct hid_hotplug_callback *hotplug_cbs;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -497,10 +497,10 @@ static struct hid_hotplug_context {
 
 	pthread_mutex_t mutex;
 
-	/* Boolean flags are set to only use 1 bit each */
-	int mutex_ready;
-	int mutex_in_use;
-	int cb_list_dirty;
+	/* Boolean flags */
+	unsigned char mutex_ready : 1;
+	unsigned char mutex_in_use : 1;
+	unsigned char cb_list_dirty : 1;
 
 	/* Linked list of the hotplug callbacks */
 	struct hid_hotplug_callback *hotplug_cbs;

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -210,10 +210,10 @@ static struct hid_hotplug_context {
 	/* Critical section (faster mutex substitute), for both cached device list and callback list changes */
 	CRITICAL_SECTION critical_section;
 
-	/* Boolean flags are set to only use 1 bit each */
-	BOOL mutex_ready : 1;
-	BOOL mutex_in_use : 1;
-	BOOL cb_list_dirty : 1;
+	/* Boolean flags */
+	BOOL mutex_ready;
+	BOOL mutex_in_use;
+	BOOL cb_list_dirty;
 
 	/* HIDAPI unique callback handle counter */
 	hid_hotplug_callback_handle next_handle;

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -519,13 +519,13 @@ static void hid_internal_hotplug_exit()
 
 int HID_API_EXPORT hid_exit(void)
 {
+    hid_internal_hotplug_exit();
+
 #ifndef HIDAPI_USE_DDK
 	free_library_handles();
 	hidapi_initialized = FALSE;
 #endif
 	register_global_error(NULL);
-
-	hid_internal_hotplug_exit();
 
 	return 0;
 }

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -211,9 +211,9 @@ static struct hid_hotplug_context {
 	CRITICAL_SECTION critical_section;
 
 	/* Boolean flags */
-	BOOL mutex_ready;
-	BOOL mutex_in_use;
-	BOOL cb_list_dirty;
+	unsigned char mutex_ready : 1;
+	unsigned char mutex_in_use : 1;
+	unsigned char cb_list_dirty : 1;
 
 	/* HIDAPI unique callback handle counter */
 	hid_hotplug_callback_handle next_handle;

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1261,7 +1261,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the critical section as IN USE, to prevent callback removal from inside a callback */
-	BOOL old_state = hid_hotplug_context.mutex_in_use;
+	unsigned char old_state = hid_hotplug_context.mutex_in_use;
 	hid_hotplug_context.mutex_in_use = 1;
 	
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -211,9 +211,9 @@ static struct hid_hotplug_context {
 	CRITICAL_SECTION critical_section;
 
 	/* Boolean flags */
-	unsigned char mutex_ready : 1;
-	unsigned char mutex_in_use : 1;
-	unsigned char cb_list_dirty : 1;
+	unsigned char mutex_ready;
+	unsigned char mutex_in_use;
+	unsigned char cb_list_dirty;
 
 	/* HIDAPI unique callback handle counter */
 	hid_hotplug_callback_handle next_handle;

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -427,6 +427,18 @@ int HID_API_EXPORT hid_init(void)
 	return 0;
 }
 
+struct hid_hotplug_callback {
+    hid_hotplug_callback_handle handle;
+    unsigned short vendor_id;
+    unsigned short product_id;
+    hid_hotplug_event events;
+    void *user_data;
+    hid_hotplug_callback_fn callback;
+
+    /* Pointer to the next notification */
+    struct hid_hotplug_callback *next;
+};
+
 static void hid_internal_hotplug_remove_postponed()
 {
 	/* Unregister the callbacks whose removal was postponed */
@@ -478,18 +490,6 @@ static void hid_internal_hotplug_cleanup()
 
 	hid_hotplug_context.notify_handle = NULL;
 }
-
-struct hid_hotplug_callback {
-	hid_hotplug_callback_handle handle;
-	unsigned short vendor_id;
-	unsigned short product_id;
-	hid_hotplug_event events;
-	void *user_data;
-	hid_hotplug_callback_fn callback;
-
-	/* Pointer to the next notification */
-	struct hid_hotplug_callback *next;
-};
 
 static void hid_internal_hotplug_exit()
 {

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1231,7 +1231,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	/* Mark the critical section as IN USE, to prevent callback removal from inside a callback */
-	int was_in_use = (2 == hid_hotplug_context.critical_section_state);
+	int old_state = hid_hotplug_context.critical_section_state;
 	hid_hotplug_context.critical_section_state = 2;
 	
 	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
@@ -1246,9 +1246,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 		}
 	}
 
-	if (!was_in_use) {
-		hid_hotplug_context.critical_section_state = 1;
-	}
+	hid_hotplug_context.critical_section_state = old_state;
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
 	return 0;


### PR DESCRIPTION
This PR provides a solution to the possible issues that happen when a register or de-register call is made from inside a callback. The way it works is the same for all platforms and is described below.

Resolves #673 

1) The mutex is made recursive, so it can be locked by the same thread multiple times
2) ~~The `mutex_ready` variable is renamed to `mutex_state`, it is no longer a boolean value, and the value of 2 in it now indicates that the mutex is "In Use" (locked by a function that calls a callback).~~ `mutex_ready` kept intact, added 2 more flags, `mutex_in_use` and `cb_list_dirty`.
3) ~~When the value of mutex_state is set to 2,~~ When the `mitex_in_use` flag is set, the Deregister call is no longer allowed to immediately remove any callbacks from the list. Instead, the `events` field in the callback is set to 0, which makes it "invalid", as it will no longer match any events, and the `cb_list_dirty` flag is set to 1 to indicate that the list needs to be checked for invalid events later.
4) When a callback returns a non-zero value, indicating that the callback is to be disarmed and removed from the list, it is marked in the same manner until the processing finishes (unless the callback was called directly by the Register call, in which case it's return value is ignored on purpose)
5) After all the callbacks are processed, if `cb_list_dirty` flag is set, the list of callbacks is checked for any callbacks marked for removal (`events` field set to 0), and those are only removed after all the processing is finished.
6) The Register call is allowed to register callbacks, as it causes no issues so long as the mutex it locks is recursive
7) Since the Register call can also call the new callback if `HID_API_HOTPLUG_ENUMERATE` is specified, ~~the `mutex_state` variable is set to 2 before it is called, while the old value is preserved and restored later.~~ `mutex_in_use` flag is set to prevent callback removal in that new callback.
8) ~~For extra safety, no callbacks are removed from the list at the end of processing in the Register call, even if there are no valid callbacks left.~~ Fixed.
9) The return value of any callbacks called for pre-existing devices is still ignored as per documentation and does not mark them invalid.