### PR TITLE
hidapi/linux: fix uninitialized variable

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -511,7 +511,7 @@ static int parse_hid_vid_pid_from_uevent_path(const char *uevent_path, unsigned 
 		return 0;
 	}
 
-	char buf[1024];
+	char buf[1024] = {0};
 	res = read(handle, buf, sizeof(buf) - 1); /* -1 for '\0' at the end */
 	close(handle);
 


### PR DESCRIPTION
In `parse_hid_vid_pid_from_uevent_path`, if the file is less than 1024 bytes somehow, the read() call will return the size of the file and pass the `if (res < 0)` check, but the leftover bytes that were not copied to from the file will remain uninitialized. This commit fixed it by initializing the buffer with 0.