### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -351,7 +351,7 @@ jobs:
         Copy-Item "windows\x64\Release\hidapi.dll","windows\x64\Release\hidapi.lib","windows\x64\Release\hidapi.pdb" -Destination "artifacts\x64"
         Copy-Item "hidapi\hidapi.h","windows\hidapi_winapi.h" -Destination "artifacts\include"
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: hidapi-win
         path: artifacts/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ jobs:
         cov-build --dir cov-int nmake
         Rename-Item ".\cov-int\emit\$(hostname)" hostname
     - name: Backup Coverity logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverity-logs-windows
         path: build/cov-int
@@ -123,7 +123,7 @@ jobs:
         cov-build --dir cov-int --append-log ninja
         mv cov-int/emit/$(hostname) cov-int/emit/hostname
     - name: Backup Coverity logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverity-logs-windows-macos
         path: build/cov-int
@@ -191,7 +191,7 @@ jobs:
           https://scan.coverity.com/builds?project=hidapi
         mv cov-int/emit/$(hostname) cov-int/emit/hostname
     - name: Backup Coverity logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverity-logs-windows-macos-linux
         path: build/cov-int

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,7 @@ jobs:
         working-directory: doxygen
 
       - name: Save doxygen docs as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: HIDAPI_doxygen_docs
           path: ${{ github.workspace }}/doxygen/html


### PR DESCRIPTION
- to match recently updated download-artifact (v3 is incompatible with v4);
- actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024;