### PR TITLE
Windows: return bytes_written in hid_write if WriteFile returns 1 (succeeds synchronously)

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -1086,7 +1086,7 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 		length = dev->output_report_length;
 	}
 
-	res = WriteFile(dev->device_handle, buf, (DWORD) length, NULL, &dev->write_ol);
+	res = WriteFile(dev->device_handle, buf, (DWORD) length, &bytes_written, &dev->write_ol);
 
 	if (!res) {
 		if (GetLastError() != ERROR_IO_PENDING) {
@@ -1095,6 +1095,9 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 			goto end_of_function;
 		}
 		overlapped = TRUE;
+	} else {
+		/* WriteFile() succeeded synchronously. */
+		function_result = bytes_written;
 	}
 
 	if (overlapped) {


### PR DESCRIPTION
Return bytes_written in hid_write if WriteFile returns 1, which means it succeeded synchronously.

According to [documentation](https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous), the system reserves the right to run WriteFile synchronously, even if FILE_FLAG_OVERLAPPED is set.

"Be careful when you code for asynchronous I/O because the system reserves the right to make an operation synchronous if it needs to. So it is best if you write the program to correctly handle an I/O operation that may be completed either synchronously or asynchronously. The sample code demonstrates this consideration."

Fixes #695