### PR TITLE
winapi: add hid_winapi_set_write_timeout

### DIFF
--- a/hidtest/test.c
+++ b/hidtest/test.c
@@ -198,6 +198,10 @@ int main(int argc, char* argv[])
  		return 1;
 	}
 
+#if defined(_WIN32) && HID_API_VERSION >= HID_API_MAKE_VERSION(0, 15, 0)
+	hid_winapi_set_write_timeout(handle, 5000);
+#endif
+
 	// Read the Manufacturer String
 	wstr[0] = 0x0000;
 	res = hid_get_manufacturer_string(handle, wstr, MAX_STR);

--- a/windows/hidapi_winapi.h
+++ b/windows/hidapi_winapi.h
@@ -67,6 +67,26 @@ extern "C" {
 		 */
 		int HID_API_EXPORT_CALL hid_winapi_descriptor_reconstruct_pp_data(void *hidp_preparsed_data, unsigned char *buf, size_t buf_size);
 
+		/**
+		 * @brief Sets the timeout for hid_write operation.
+		 *
+		 * Since version 0.15.0, @ref HID_API_VERSION >= HID_API_MAKE_VERSION(0, 15, 0)
+		 *
+		 * The default timeout is 1sec for winapi backend.
+		 *
+		 * In case if 1sec is not enough, on in case of multi-platform development,
+		 * the recommended value is 5sec, e.g. to match (unconfigurable) 5sec timeout
+		 * set for hidraw (linux kernel) implementation.
+		 *
+		 * When the timeout is set to 0, hid_write function becomes non-blocking and would exit immediately.
+		 * When the timeout is set to INFINITE ((DWORD)-1), the function will not exit,
+		 * until the write operation is performed or an error occured.
+		 * See dwMilliseconds parameter documentation of WaitForSingleObject function.
+		 *
+		 * @param timeout New timeout value in milliseconds.
+		 */
+		void HID_API_EXPORT_CALL hid_winapi_set_write_timeout(hid_device *dev, unsigned long timeout);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add API function to control hid_write timeout on WinAPI backend.

Resolves: #686