### PR TITLE
Ensure last_error_str released on macOS

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -195,6 +195,7 @@ static void free_hid_device(hid_device *dev)
 	if (dev->source)
 		CFRelease(dev->source);
 	free(dev->input_report_buf);
+	free(dev->last_error_str);
 	hid_free_enumeration(dev->device_info);
 
 	/* Clean up the thread objects */


### PR DESCRIPTION
Found by Coverity: it appears `dev->last_error_str` never been freed on macOS.