### PR TITLE
Fix Archlinux CI build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -485,7 +485,7 @@ jobs:
         cmake \
           -B build/shared_test \
           -S hidapisrc/hidtest \
-          -Dhidapi_ROOT=install/shared-cmake \
+          -Dhidapi_ROOT=$(pwd)/install/shared-cmake \
           -DCMAKE_INSTALL_PREFIX=install/shared_test \
           "-DCMAKE_C_FLAGS=${GNU_COMPILE_FLAGS}"
         cd build/shared_test
@@ -495,7 +495,7 @@ jobs:
         cmake \
           -B build/static_test \
           -S hidapisrc/hidtest \
-          -Dhidapi_ROOT=install/static-cmake \
+          -Dhidapi_ROOT=$(pwd)/install/static-cmake \
           -DCMAKE_INSTALL_PREFIX=install/static_test \
           "-DCMAKE_C_FLAGS=${GNU_COMPILE_FLAGS}"
         cd build/static_test


### PR DESCRIPTION
Fix CI build on latest Archlinux with CMake 4.0

Fixes: #732