### PR TITLE
linux/hidraw: Add support for BUS_VIRTUAL

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -146,7 +146,10 @@ extern "C" {
 			HID_API_BUS_SPI = 0x04,
 
 			/** Virtual device
-			    E.g.: https://elixir.bootlin.com/linux/v4.0/source/include/uapi/linux/input.h#L955 */
+			    E.g.: https://elixir.bootlin.com/linux/v4.0/source/include/uapi/linux/input.h#L955 
+			    
+			    Since version 0.16.0, @ref HID_API_VERSION >= HID_API_MAKE_VERSION(0, 16, 0)
+			    */
 			HID_API_BUS_VIRTUAL = 0x05,
 		} hid_bus_type;
 

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -144,6 +144,9 @@ extern "C" {
 			   Specifications:
 			   https://www.microsoft.com/download/details.aspx?id=103325 */
 			HID_API_BUS_SPI = 0x04,
+
+			/** Virtual bus */
+			HID_API_BUS_VIRTUAL = 0x05,
 		} hid_bus_type;
 
 		/** hidapi info structure */

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -149,7 +149,7 @@ extern "C" {
 			    E.g.: https://elixir.bootlin.com/linux/v4.0/source/include/uapi/linux/input.h#L955 
 			    
 			    Since version 0.16.0, @ref HID_API_VERSION >= HID_API_MAKE_VERSION(0, 16, 0)
-			    */
+			*/
 			HID_API_BUS_VIRTUAL = 0x05,
 		} hid_bus_type;
 

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -145,7 +145,8 @@ extern "C" {
 			   https://www.microsoft.com/download/details.aspx?id=103325 */
 			HID_API_BUS_SPI = 0x04,
 
-			/** Virtual bus */
+			/** Virtual device
+			    E.g.: https://elixir.bootlin.com/linux/v4.0/source/include/uapi/linux/input.h#L955 */
 			HID_API_BUS_VIRTUAL = 0x05,
 		} hid_bus_type;
 

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -683,6 +683,7 @@ static struct hid_device_info * create_device_info_for_device(struct udev_device
 		case BUS_I2C:
 		case BUS_USB:
 		case BUS_SPI:
+		case BUS_VIRTUAL:
 			break;
 
 		default:
@@ -776,6 +777,14 @@ static struct hid_device_info * create_device_info_for_device(struct udev_device
 			cur_dev->product_string = utf8_to_wchar_t(product_name_utf8);
 
 			cur_dev->bus_type = HID_API_BUS_SPI;
+
+			break;
+
+		case BUS_VIRTUAL:
+			cur_dev->manufacturer_string = wcsdup(L"");
+			cur_dev->product_string = utf8_to_wchar_t(product_name_utf8);
+
+			cur_dev->bus_type = HID_API_BUS_VIRTUAL;
 
 			break;
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -804,6 +804,7 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 	case HID_API_BUS_UNKNOWN:
 	case HID_API_BUS_SPI:
 	case HID_API_BUS_I2C:
+	case HID_API_BUS_VIRTUAL:
 		/* shut down -Wswitch */
 		break;
 	}


### PR DESCRIPTION
This driver implements a virtual HID device on linux: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/drivers/platform/x86/tuxedo/nb04/wmi_ab.c?id=cfd84b3f419bf0aec60ecddc92c61b539c339ec9#n841

This patch enables HIDAPI to handle this correctly.

Fixes: https://github.com/libusb/hidapi/issues/744