### PR TITLE
Draft: linux/hidraw: Parse Report ID

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -176,6 +176,9 @@ extern "C" {
 			/** Usage for this Device/Interface
 			    (Windows/Mac/hidraw only) */
 			unsigned short usage;
+			/** Report ID for this Device/Interface
+			    (hidraw only) */
+			unsigned char report_id;
 			/** The USB interface which this logical device
 			    represents.
 


### PR DESCRIPTION
I didn't see a way to retrive Report IDs using hidapi, but sometimes these are required because they are optional and/or different on a per device basis and must be prefixed to reports sent. So I made this quick and currently untested Patch as a conversation starter if and how this could be added.

Or am I missing something completly?