### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -282,7 +282,7 @@ static __u32 get_hid_report_bytes(const __u8 *rpt, size_t len, size_t num_bytes,
  * Skips all nested Collection, i.e. iterates until the end of current level Collection.
  *
  * The return value is non-0 when an end of current Collection is found,
- * 0 when error is occured (broken Descriptor, end of a Collection is found before its begin,
+ * 0 when error is occurred (broken Descriptor, end of a Collection is found before its begin,
  *  or no Collection is found at all).
  */
 static int hid_iterate_over_collection(const __u8 *report_descriptor, __u32 size, unsigned int *pos, int *data_len, int *key_size)

--- a/netbsd/hid.c
+++ b/netbsd/hid.c
@@ -247,7 +247,7 @@ static uint32_t get_hid_report_bytes(const uint8_t *rpt, size_t len, size_t num_
  * Skips all nested Collection, i.e. iterates until the end of current level Collection.
  *
  * The return value is non-0 when an end of current Collection is found,
- * 0 when error is occured (broken Descriptor, end of a Collection is found before its begin,
+ * 0 when error is occurred (broken Descriptor, end of a Collection is found before its begin,
  *  or no Collection is found at all).
  */
 static int hid_iterate_over_collection(const uint8_t *report_descriptor, uint32_t size, unsigned int *pos, int *data_len, int *key_size)

--- a/windows/hidapi_descriptor_reconstruct.c
+++ b/windows/hidapi_descriptor_reconstruct.c
@@ -400,11 +400,11 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				collection_node_idx = coll_child_order[collection_node_idx][0];
 
 				// In a HID Report Descriptor, the first usage declared is the most preferred usage for the control.
-				// While the order in the WIN32 capabiliy strutures is the opposite:
+				// While the order in the WIN32 capabiliy structures is the opposite:
 				// Here the preferred usage is the last aliased usage in the sequence.
 
 				if (link_collection_nodes[collection_node_idx].IsAlias && (firstDelimiterNode == NULL)) {
-					// Alliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
+					// Aliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
 					firstDelimiterNode = main_item_list;
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_usage, 0, &main_item_list);
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_close, 0, &main_item_list);
@@ -430,7 +430,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				collection_node_idx = coll_child_order[collection_node_idx][nextChild];
 												
 				if (link_collection_nodes[collection_node_idx].IsAlias && (firstDelimiterNode == NULL)) {
-					// Alliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
+					// Aliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
 					firstDelimiterNode = main_item_list;
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_usage, 0, &main_item_list);
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_close, 0, &main_item_list);
@@ -490,11 +490,11 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 			list_node = rd_search_main_item_list_for_bit_position(first_bit, (rd_main_items) rt_idx, pp_data->caps[caps_idx].ReportID, &coll_begin);
 
 			// In a HID Report Descriptor, the first usage declared is the most preferred usage for the control.
-			// While the order in the WIN32 capabiliy strutures is the opposite:
+			// While the order in the WIN32 capabiliy structures is the opposite:
 			// Here the preferred usage is the last aliased usage in the sequence.
 
 			if (pp_data->caps[caps_idx].IsAlias && (firstDelimiterNode == NULL)) {
-				// Alliased Usage (First node in pp_data->caps -> Last entry in report descriptor output)
+				// Aliased Usage (First node in pp_data->caps -> Last entry in report descriptor output)
 				firstDelimiterNode = list_node;
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_usage, pp_data->caps[caps_idx].ReportID, &list_node);
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_close, pp_data->caps[caps_idx].ReportID, &list_node);
@@ -503,7 +503,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_usage, pp_data->caps[caps_idx].ReportID, &list_node);
 			}
 			else if (!pp_data->caps[caps_idx].IsAlias && (firstDelimiterNode != NULL)) {
-				// Alliased Collection (Last node in pp_data->caps -> First entry in report descriptor output)
+				// Aliased Collection (Last node in pp_data->caps -> First entry in report descriptor output)
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_usage, pp_data->caps[caps_idx].ReportID, &list_node);
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_open, pp_data->caps[caps_idx].ReportID, &list_node);
 				firstDelimiterNode = NULL;
@@ -561,7 +561,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				}
 			}
 			if (list->next->MainItemType == rd_collection_end) {
-				// Store the node before the collection end - the last occurence is the end of the top level collection
+				// Store the node before the collection end - the last occurrence is the end of the top level collection
 				node_before_top_level_coll_end = list;
 			}
 			list = list->next;

--- a/windows/hidapi_winapi.h
+++ b/windows/hidapi_winapi.h
@@ -80,7 +80,7 @@ extern "C" {
 		 *
 		 * When the timeout is set to 0, hid_write function becomes non-blocking and would exit immediately.
 		 * When the timeout is set to INFINITE ((DWORD)-1), the function will not exit,
-		 * until the write operation is performed or an error occured.
+		 * until the write operation is performed or an error occurred.
 		 * See dwMilliseconds parameter documentation of WaitForSingleObject function.
 		 *
 		 * @param timeout New timeout value in milliseconds.

--- a/windows/pp_data_dump/pp_data_dump.c
+++ b/windows/pp_data_dump/pp_data_dump.c
@@ -85,8 +85,8 @@ void dump_hidp_link_collection_node(FILE* file, phid_pp_link_collection_node pco
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->NumberOfChildren   = %hu\n", coll_idx, pcoll->NumberOfChildren);
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->NextSibling        = %hu\n", coll_idx, pcoll->NextSibling);
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->FirstChild         = %hu\n", coll_idx, pcoll->FirstChild);
-	// The compilers are not consistent on ULONG-bit-fields: They lose the unsinged or define them as int.
-	// Thus just always cast them to unsinged int, which should be fine, as the biggest bit-field is 28 bit
+	// The compilers are not consistent on ULONG-bit-fields: They lose the unsigned or define them as int.
+	// Thus just always cast them to unsigned int, which should be fine, as the biggest bit-field is 28 bit
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->CollectionType     = %u\n", coll_idx, (unsigned int)(pcoll->CollectionType));
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->IsAlias            = %u\n", coll_idx, (unsigned int)(pcoll->IsAlias));
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->Reserved           = 0x%08X\n", coll_idx, (unsigned int)(pcoll->Reserved));


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>
