### PR TITLE
Fix compilation with WIN32_LEAN_AND_MEAN and use it for hid.c

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -30,6 +30,11 @@
 extern "C" {
 #endif
 
+#ifndef WIN32_LEAN_AND_MEAN
+/* Reduces the overhead from windows.h */
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include "hidapi_winapi.h"
 
 #include <windows.h>

--- a/windows/hidapi_cfgmgr32.h
+++ b/windows/hidapi_cfgmgr32.h
@@ -32,6 +32,7 @@
 /* This part of the header mimics cfgmgr32.h,
     but only what is used by HIDAPI */
 
+#include <ole2.h>
 #include <initguid.h>
 #include <devpropdef.h>
 #include <propkeydef.h>


### PR DESCRIPTION
Fixes #766

Defining WIN32_LEAN_AND_MEAN removes some rarely-used includes from windows.h, which MSVC uses to speed up compilation. Unfortunately, hidapi_cfgmgr32.h relies on one of those headers. This PR fixes the missing header, as well as makes use of the speed-up define, simultaneously making the build scenarios more uniform regardless of whether the target project uses it or not.