### PR TITLE
Fix compilation with WIN32_LEAN_AND_MEAN (through UNDEF)

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -30,6 +30,11 @@
 extern "C" {
 #endif
 
+#ifdef WIN32_LEAN_AND_MEAN
+/* This define may be set by IDE/project and it breaks compilation */
+#undef WIN32_LEAN_AND_MEAN
+#endif
+
 #include "hidapi_winapi.h"
 
 #include <windows.h>

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -31,7 +31,8 @@ extern "C" {
 #endif
 
 #ifdef WIN32_LEAN_AND_MEAN
-/* This define may be set by IDE/project and it breaks compilation */
+/* It may be set by IDE/project and apparently HIDAPI relies
+ * on certain Windows headers being included by default. */
 #undef WIN32_LEAN_AND_MEAN
 #endif
 


### PR DESCRIPTION
Fixes #766 
This version is less complicated and just undefines the thing. The previous PR with a proper solution didn't work well with CI, trying a simpler solution.