### PR TITLE
Update macOS runner version for Coverity job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,7 +71,7 @@ jobs:
 
 
   coverity-macos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: [coverity-windows]
 
     steps:


### PR DESCRIPTION
See: 
- https://github.com/libusb/hidapi/commit/bda710178dfe9650bdf76aa02e3671e17e3a8a27
- https://github.com/libusb/hidapi/commit/6c2de304317d2e48c463399e0401ae6e406cd7c6

See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/