### PR TITLE
netbsd: check if iconv(3) requires pointer-to-const as libusb does

### DIFF
--- a/netbsd/CMakeLists.txt
+++ b/netbsd/CMakeLists.txt
@@ -10,6 +10,16 @@ find_package(Threads REQUIRED)
 
 target_link_libraries(hidapi_netbsd PRIVATE Threads::Threads)
 
+# check for error: "conflicting types for 'iconv'"
+include(CheckCSourceCompiles)
+check_c_source_compiles("#include<iconv.h>
+    extern size_t iconv (iconv_t cd, const char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft);
+    int main() {}"
+HIDAPI_ICONV_CONST)
+if(HIDAPI_ICONV_CONST)
+    target_compile_definitions(hidapi_netbsd PRIVATE "ICONV_CONST=const")
+endif()
+
 set_target_properties(hidapi_netbsd
     PROPERTIES
         EXPORT_NAME "netbsd"

--- a/netbsd/hid.c
+++ b/netbsd/hid.c
@@ -30,6 +30,10 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <iconv.h>
+#ifndef ICONV_CONST
+#define ICONV_CONST
+#endif
+
 #include <poll.h>
 
 /* NetBSD */
@@ -1087,7 +1091,7 @@ int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index
 	struct usb_string_desc usd;
 	usb_string_descriptor_t *str;
 	iconv_t ic;
-	const char *src;
+	ICONV_CONST char *src;
 	size_t srcleft;
 	char *dst;
 	size_t dstleft;
@@ -1131,7 +1135,7 @@ int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index
 		return -1;
 	}
 
-	src = (const char *) str->bString;
+	src = (ICONV_CONST char *)str->bString;
 	srcleft = str->bLength - 2;
 	dst = (char *) string;
 	dstleft = sizeof(wchar_t[maxlen]);


### PR DESCRIPTION
The iconv(3) prototype has been changed since NetBSD 10 to sync with the standard:
 https://man.netbsd.org/NetBSD-10.0/iconv.3#STANDARDS