### PR TITLE
netbsd: check not only addr 0 but also addr 1 to find root hubs

### DIFF
--- a/netbsd/hid.c
+++ b/netbsd/hid.c
@@ -724,6 +724,7 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 	for (size_t i = 0; i < len; i++) {
 		char devpath[USB_MAX_DEVNAMELEN];
 		int bus;
+		struct hid_device_info *prev_end;
 
 		strlcpy(devpath, "/dev/", sizeof(devpath));
 		strlcat(devpath, arr[i], sizeof(devpath));
@@ -732,7 +733,17 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 		if (bus == -1)
 			continue;
 
+		/*
+		 * ehci/ohci/uhci/dwctwo etc. use 'addr 1' for root hubs
+		 * but xhci uses 'addr 0' on NetBSD.
+		 * Check addr 0 (that would be unused on other than xhci)
+		 * and then check addr 1 if there is no device at addr 0.
+		 */
+		prev_end = hed.end;
 		enumerate_usb_devices(bus, 0, hid_enumerate_callback, &hed);
+		if (hed.end == prev_end)
+			enumerate_usb_devices(bus, 1,
+			    hid_enumerate_callback, &hed);
 
 		close(bus);
 	}


### PR DESCRIPTION
On NetBSD xhci(4) uses 'addr 0' for the root hub but all drivers for other host controllers use 'addr 1' for the root hub.
 https://gnats.netbsd.org/60073

---

Tested with [ch32fun](https://github.com/cnlohr/ch32fun) on NetBSD/i386 10.1 both with xhci(4) and ohci(4).