### PR TITLE
Fix high CPU usage in callback thread due to incorrect timespec

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1215,16 +1215,16 @@ static void* callback_thread(void* user_data)
 {
 	(void) user_data;
 
-	/* 5 msec timeout seems reasonable; don't set too low to avoid high CPU usage */
-	/* This timeout only affects how much time it takes to stop the thread */
-	hidapi_timespec ts;
-	ts.tv_sec = 0;
-	ts.tv_nsec = 5000000;
-
 	hidapi_thread_mutex_lock(&hid_hotplug_context.callback_thread);
 	
 	/* We stop the thread if by the moment there are no events left in the queue there are no callbacks left */
 	while (1) {
+		/* 5 msec timeout seems reasonable; don't set too low to avoid high CPU usage */
+		/* This timeout only affects how much time it takes to stop the thread */
+		hidapi_timespec ts;
+		hidapi_thread_gettime(&ts);
+		hidapi_thread_addtime(&ts, 5);
+
 		/* Make the tread fall asleep and wait for a condition to wake it up */
 		hidapi_thread_cond_timedwait(&hid_hotplug_context.callback_thread, &ts);
 

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1219,11 +1219,11 @@ static void* callback_thread(void* user_data)
 	
 	/* We stop the thread if by the moment there are no events left in the queue there are no callbacks left */
 	while (1) {
-		/* 5 msec timeout seems reasonable; don't set too low to avoid high CPU usage */
-		/* This timeout only affects how much time it takes to stop the thread */
+		/* Pretty much any value between 2 and 100 msec timeout seems reasonable; don't set too low to avoid high CPU usage */
+		/* This timeout only affects how much time it takes to stop the thread if for any reason thread shutdown wasn't triggered by condition varaiable */
 		hidapi_timespec ts;
 		hidapi_thread_gettime(&ts);
-		hidapi_thread_addtime(&ts, 5);
+		hidapi_thread_addtime(&ts, 100);
 
 		/* Make the tread fall asleep and wait for a condition to wake it up */
 		hidapi_thread_cond_timedwait(&hid_hotplug_context.callback_thread, &ts);


### PR DESCRIPTION
@CalcProgrammer1 noticed high CPU usage (50%) on one of the threads when libusb backend is used for hotplug. It was determined that the load was caused by `hidapi_thread_cond_timedwait()`, which requires an absolute timespec, while the code passes a relative value. This patch copies how the structure is filled from the other place where `hidapi_thread_cond_timedwait()` is uses, which should fix the issue.