### PR TITLE
windows: guard static_assert with __STDC_VERSION__ for C99 compatibility

### DIFF
--- a/windows/hidapi_descriptor_reconstruct.h
+++ b/windows/hidapi_descriptor_reconstruct.h
@@ -124,8 +124,12 @@ typedef struct hid_pp_link_collection_node_ {
 //       Although very unlikely, it might still be possible that the compiler creates a memory layout that is
 //       not binary compatile.
 //       Other structs are not checked at the time of writing.
+// static_assert was added to <assert.h> in C11; skip this check when the
+// translation unit is compiled as C99 or earlier, where it is unavailable.
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 static_assert(sizeof(struct hid_pp_link_collection_node_) == 16,
     "Size of struct hid_pp_link_collection_node_ not as expected. This might break binary compatibility");
+#endif
 
 typedef struct hidp_unknown_token_ {
 	UCHAR Token; /* Specifies the one-byte prefix of a global item. */


### PR DESCRIPTION
## Problem

`windows/hidapi_descriptor_reconstruct.h:127` uses `static_assert` to sanity-check the in-memory layout of `hid_pp_link_collection_node_`:

```c
static_assert(sizeof(struct hid_pp_link_collection_node_) == 16, ...);
```

`static_assert` was added to `<assert.h>` in C11. Building with `-std=c99` — for example via `set(CMAKE_C_STANDARD 99)` in a parent CMake project, as reported in #764 — fails at that line on mingw/gcc:

```
windows/hidapi_descriptor_reconstruct.h:127:15: error: expected declaration specifiers or '...' before 'sizeof'
```

## Change

The assertion's preceding comment describes it as a "risk-reduction-measure" rather than a strict requirement. Guard it:

```c
#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
static_assert(...);
#endif
```

- C11 / C17 / C23 toolchains still get the compile-time check (behaviour unchanged).
- C99 and earlier skip it and build cleanly.
- MSVC in its default C mode (where `__STDC_VERSION__` is typically not set that high) also skips it — a minor reduction in the safety net there, but the production build is unaffected.

Net diff: +4 / -0 in one file.

## Verification

Reproduced and fixed locally with `x86_64-w64-mingw32-gcc` (GCC 10, MinGW-w64) in WSL, compiling the real backend sources:

| build | `-std=c99` | `-std=c11` |
|-------|------------|------------|
| master (no fix) | **fail** — `error: expected declaration specifiers or '...' before 'sizeof'` at L127 | pass |
| this PR | pass | pass |

Tested with both `windows/hid.c` and `windows/hidapi_descriptor_reconstruct.c` (the two sources that include the affected header).

Closes #764.

_Drafted with Claude Code._
