### PR TITLE
libusb: make hid.c compile cleanly as C++

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -20,7 +20,9 @@
         https://github.com/libusb/hidapi .
 ********************************************************/
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* needed for wcsdup() before glibc 2.10 */
+#endif
 
 /* C */
 #include <stdio.h>
@@ -86,11 +88,16 @@ struct input_report {
 
 
 typedef struct hidapi_error_ctx_ {
-	enum libusb_error error_code;
+	/* libusb error code (negative LIBUSB_ERROR_* values or LIBUSB_SUCCESS),
+	 * or a sentinel non-zero value when set via register_string_error().
+	 * Stored as plain int so call sites can pass libusb return values
+	 * (which are typed as int) without an explicit cast — that keeps
+	 * libusb/hid.c compilable as C++ as well as C. */
+	int error_code;
 	/* designed to hold string literals only - do not free */
 	const char *error_context;
 
-	enum libusb_error last_error_code_cache;
+	int last_error_code_cache;
 	const char *last_error_context_cache;
 	/* dynamically allocated */
 	wchar_t *last_error_str;
@@ -334,7 +341,7 @@ static wchar_t *ctowcdup(const char *s, size_t slen)
 }
 
 
-static void register_libusb_error(hidapi_error_ctx *err, enum libusb_error error, const char *error_context)
+static void register_libusb_error(hidapi_error_ctx *err, int error, const char *error_context)
 {
 	err->error_code = error;
 	err->error_context = error_context;
@@ -382,7 +389,7 @@ static wchar_t *utf_to_wchar(char *utf, size_t utfbytes, const char *fromcode, s
 	}
 
 	wbuf_size = (max_expected_wchar + 1) * sizeof(wchar_t);
-	wbuf = malloc(wbuf_size);
+	wbuf = (wchar_t *) malloc(wbuf_size);
 	if (!wbuf) {
 		goto end;
 	}
@@ -719,7 +726,7 @@ static void invasive_fill_device_info_usage(struct hid_device_info *cur_dev, lib
 static struct hid_device_info * create_device_info_for_device(libusb_device *device, libusb_device_handle *handle, struct libusb_device_descriptor *desc, int config_number, int interface_num)
 {
 	int res = 0;
-	struct hid_device_info *cur_dev = calloc(1, sizeof(struct hid_device_info));
+	struct hid_device_info *cur_dev = (struct hid_device_info *) calloc(1, sizeof(struct hid_device_info));
 	if (cur_dev == NULL) {
 		return NULL;
 	}
@@ -923,7 +930,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 
 	num_devs = libusb_get_device_list(usb_context, &devs);
 	if (num_devs < 0) {
-		register_libusb_error(&last_global_error, (enum libusb_error)num_devs, "libusb_get_device_list");
+		register_libusb_error(&last_global_error, num_devs, "libusb_get_device_list");
 		return NULL;
 	}
 	while ((dev = devs[i++]) != NULL) {
@@ -1091,7 +1098,7 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const
 
 static void LIBUSB_CALL read_callback(struct libusb_transfer *transfer)
 {
-	hid_device *dev = transfer->user_data;
+	hid_device *dev = (hid_device *) transfer->user_data;
 	int res;
 
 	if (transfer->status == LIBUSB_TRANSFER_COMPLETED) {
@@ -1160,7 +1167,7 @@ static void LIBUSB_CALL read_callback(struct libusb_transfer *transfer)
 static void *read_thread(void *param)
 {
 	int res;
-	hid_device *dev = param;
+	hid_device *dev = (hid_device *) param;
 	uint8_t *buf;
 	const size_t length = dev->input_ep_max_packet_size;
 
@@ -1636,7 +1643,7 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 
 static void cleanup_mutex(void *param)
 {
-	hid_device *dev = param;
+	hid_device *dev = (hid_device *) param;
 	hidapi_thread_mutex_unlock(&dev->thread_state);
 }
 
@@ -2100,7 +2107,7 @@ HID_API_EXPORT const wchar_t * HID_API_CALL hid_error(hid_device *dev)
 		return L"Error string format error";
 	}
 
-	buffer = malloc((size_t)len + 1); /* +1 for terminating NULL */
+	buffer = (char *) malloc((size_t)len + 1); /* +1 for terminating NULL */
 	if (!buffer) {
 		return L"Error string memory allocation error";
 	}


### PR DESCRIPTION
## Problem

`libusb/hid.c` doesn't compile cleanly as C++, as reported in #671. Reproduced on current master with `g++ -xc++ -Wall -Wextra -c libusb/hid.c`:

```
libusb/hid.c:23: warning: "_GNU_SOURCE" redefined
libusb/hid.c:385:22: error: invalid conversion from 'void*' to 'wchar_t*'
libusb/hid.c:722:49: error: invalid conversion from 'void*' to 'hid_device_info*'
libusb/hid.c:1094:37: error: invalid conversion from 'void*' to 'hid_device*'
libusb/hid.c:1163:27: error: invalid conversion from 'void*' to 'hid_device*'
libusb/hid.c:1639:27: error: invalid conversion from 'void*' to 'hid_device*'
libusb/hid.c:2103:24: error: invalid conversion from 'void*' to 'char*'
libusb/hid.c:349:56: error: invalid conversion from 'int' to 'libusb_error'
libusb/hid.c:605:67: error: invalid conversion from 'int' to 'libusb_error'
... (13 such int → libusb_error sites total)
```

Three C-only patterns are involved:

1. **Implicit `void*` to typed pointer** conversions from `malloc` / `calloc` / pthread-style `void *param` (6 sites).
2. **Implicit `int` to `enum libusb_error`** conversions when storing libusb return codes (typed `int`) into the `hidapi_error_ctx` fields or passing them to `register_libusb_error()` (13 sites).
3. **`#define _GNU_SOURCE`** without an `#ifndef` guard — emits a `"_GNU_SOURCE" redefined` warning when the macro is also supplied via `-D` on the command line.

## Change

Minimal fix, scoped to `libusb/hid.c`:

- Wrap `#define _GNU_SOURCE` in `#ifndef _GNU_SOURCE`.
- Change the internal `hidapi_error_ctx` struct's `error_code` / `last_error_code_cache` and the `register_libusb_error()` `error` parameter from `enum libusb_error` to plain `int`. The struct is internal (not exported), the stored values are already a mix of libusb error codes and a `1` sentinel from `register_string_error()`, and using `int` removes 13 call-site conversions in a single structural change.
- Add explicit C-style casts on the 6 `malloc` / `calloc` / `void*` sites. This matches the convention already in `windows/hid.c` and `mac/hid.c`.
- Drop a now-redundant `(enum libusb_error)` cast at `libusb_get_device_list`'s error path.

Net diff: 17 insertions, 10 deletions in one file.

## Verification

On WSL Ubuntu (gcc 11.4, libusb-1.0):

| build | result |
|-------|--------|
| `g++ -xc++ -Wall -Wextra -c libusb/hid.c` | **clean** — was 19 errors + 1 warning |
| `gcc -Wall -Wextra -c libusb/hid.c` | **clean** — no change for the C build |
| full CMake build of the libusb backend (`libhidapi-libusb.so`, `hidtest_libusb`) | builds and links unchanged |

Closes #671.

_Drafted with Claude Code._
