### PR TITLE
ci: build libusb and hidraw backends as C++ on ubuntu

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -154,6 +154,21 @@ jobs:
         cd build/static_test
         make install
 
+    - name: Check C++ compile (backends as C++ sources)
+      working-directory: hidapisrc
+      # Verify the libusb/hidraw backend sources still compile as C++,
+      # so regressions of #671 are caught. -pedantic is intentionally not
+      # used here: libusb.h declares zero-size arrays and we rely on
+      # designated initialisers, both GNU extensions that g++ accepts in
+      # its default mode but rejects under strict ISO C++.
+      run: |
+        g++ -xc++ -Wall -Wextra -Werror -Wformat-signedness -D_GNU_SOURCE \
+          -I hidapi -I libusb $(pkg-config --cflags libusb-1.0) \
+          -c libusb/hid.c -o /tmp/hid_libusb_cxx.o
+        g++ -xc++ -Wall -Wextra -Werror -Wformat-signedness -D_GNU_SOURCE \
+          -I hidapi -I linux $(pkg-config --cflags libudev) \
+          -c linux/hid.c -o /tmp/hid_hidraw_cxx.o
+
     - name: Check Meson build
       run: |
         meson setup build_meson hidapisrc


### PR DESCRIPTION
## Why

Issue #671 reported that `libusb/hid.c` failed to compile as C++ source. PR #811 made it C++-clean; `linux/hid.c` already builds as C++. Today nothing in CI exercises the C++ compilation path, so a similar regression could slip through unnoticed.

## Change

Add a single step to the `ubuntu-cmake` job that compiles both backend `hid.c` files with `g++ -xc++`:

```yaml
- name: Check C++ compile (backends as C++ sources)
  working-directory: hidapisrc
  run: |
    g++ -xc++ -Wall -Wextra -Werror -Wformat-signedness -D_GNU_SOURCE \
      -I hidapi -I libusb $(pkg-config --cflags libusb-1.0) \
      -c libusb/hid.c -o /tmp/hid_libusb_cxx.o
    g++ -xc++ -Wall -Wextra -Werror -Wformat-signedness -D_GNU_SOURCE \
      -I hidapi -I linux $(pkg-config --cflags libudev) \
      -c linux/hid.c -o /tmp/hid_hidraw_cxx.o
```

Flag set mirrors `GNU_COMPILE_FLAGS` used by the existing C build, **except** `-pedantic` is omitted. Rationale: `libusb.h` declares zero-size arrays (`#define ZERO_SIZED_ARRAY 0`) and hidapi relies on designated initialisers — both GNU extensions that g++ accepts in its default mode but rejects under strict ISO C++. The check is meant to catch real cross-language regressions (#671-style implicit conversions), not those existing-by-design extensions.

No source changes; this only adds the CI guard.

## Verification

Ran the exact two commands locally against current master in WSL Ubuntu (gcc/g++ 11.4, libusb-1.0):

```
libusb/hid.c as C++: OK
linux/hid.c as C++: OK
```

Also confirmed that reverting commit `e8243e1` (the #671 fix) makes the libusb command fail with the same `invalid conversion` errors the original issue reported — so this CI step will actually catch a regression of that fix.

_Drafted with Claude Code._
