### PR TITLE
mac: fix -Wgnu-folding-constant build error on newer Apple clang

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -544,8 +544,8 @@ static struct hid_device_info *create_device_info_with_usage(IOHIDDeviceRef dev,
 {
 	unsigned short dev_vid;
 	unsigned short dev_pid;
-	const int BUF_LEN = 256;
-	wchar_t buf[BUF_LEN];
+	enum { BufLen = 256 };
+	wchar_t buf[BufLen];
 	CFTypeRef transport_prop;
 
 	struct hid_device_info *cur_dev;
@@ -598,13 +598,13 @@ static struct hid_device_info *create_device_info_with_usage(IOHIDDeviceRef dev,
 	}
 
 	/* Serial Number */
-	get_serial_number(dev, buf, BUF_LEN);
+	get_serial_number(dev, buf, BufLen);
 	cur_dev->serial_number = dup_wcs(buf);
 
 	/* Manufacturer and Product strings */
-	get_manufacturer_string(dev, buf, BUF_LEN);
+	get_manufacturer_string(dev, buf, BufLen);
 	cur_dev->manufacturer_string = dup_wcs(buf);
-	get_product_string(dev, buf, BUF_LEN);
+	get_product_string(dev, buf, BufLen);
 	cur_dev->product_string = dup_wcs(buf);
 
 	/* VID/PID */


### PR DESCRIPTION
## Summary

`create_device_info_with_usage()` in `mac/hid.c` declared the local buffer length as a `const int`:

```c
const int BUF_LEN = 256;
wchar_t buf[BUF_LEN];
```

In C a `const`-qualified variable is not a constant expression, so `buf` is technically a VLA that the compiler folds to a fixed-size array. Newer Apple clang (clang 21, shipped with macOS 26) reports the fold under `-Wgnu-folding-constant`; since the project builds with `-pedantic -Werror`, it becomes a hard error:

```
mac/hid.c:548:14: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
```

Use an `enum` constant instead — a proper integer constant expression — so `buf` is an ordinary fixed-size array on every compiler. It is named `BufLen` (not `BUF_LEN`) so an all-caps identifier can't collide with a macro of the same name. No behavior change.

The CI macOS runner's clang doesn't flag this yet, so it builds green there, but it breaks local builds on up-to-date Macs. Reported by @mcuee while testing the virtual-device tests (#815) on macOS 26.5.1 / Apple clang 21.

Refs: #815

Assisted-by: claude-code:claude-opus-4-8
