### PR TITLE
Share AI agent contribution rules across agents via AGENTS.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,26 @@
+# Project memory for Claude — libusb/hidapi
+
+The contribution and commit rules for this repository are maintained as a single source of
+truth in [`AGENTS.md`](../AGENTS.md) at the repository root, shared by every AI coding agent
+(Codex, Cursor, GitHub Copilot, Gemini CLI, Claude Code, and others). Claude Code loads them
+via the import below, so there is no second copy to keep in sync.
+
+@../AGENTS.md
+
+## Attribution when posting to GitHub on the user's behalf
+
+When using `gh` to post PR comments, reviews, or issues from the user's
+GitHub account (e.g. `gh pr comment`, `gh pr review`, `gh issue create`,
+or `gh api` against `/reviews`, `/comments`, `/issues`), include a brief
+attribution line at the end of the body indicating the message was
+drafted by Claude.
+
+Keep it to one short final line, plain text. Example:
+
+> _Drafted with Claude Code._
+
+Does **not** apply to:
+- Commit messages and PR descriptions — those carry the `Assisted-by:` trailer
+  described in [`AGENTS.md`](../AGENTS.md) instead.
+- Messages the user explicitly dictates verbatim.
+- Read-only GitHub calls (`gh pr view`, `gh api GET`, etc.).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Contribution Guidelines for AI Coding Agents
+
+The contribution and commit rules for this repository are maintained as a single source of
+truth in [`AGENTS.md`](../AGENTS.md) at the repository root. Follow the rules there for every
+commit and pull request. GitHub Copilot's coding agent reads `AGENTS.md` directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Contribution Guidelines for AI Coding Agents
+
+These are the canonical contribution and commit rules for this repository. They apply to
+**every** AI coding agent used on this project (OpenAI Codex, Cursor, GitHub Copilot, Claude
+Code, Gemini CLI, and others) and to any automation acting on a contributor's behalf.
+
+This file (`AGENTS.md`) is the single source of truth. Most agents read it natively; the few
+that use a dedicated file load these same rules from here — `.claude/CLAUDE.md` and `GEMINI.md`
+import it, and `.github/copilot-instructions.md` points to it — so there is only ever one copy
+to maintain.
+
+## Commit Authorship
+
+Every commit in this repository must be authored by a human (the contributor). No AI agent
+(Codex, Cursor, GitHub Copilot, Claude, Gemini, or any other) may be set as the commit author.
+
+At the end of every commit message, include an explicit attribution trailer indicating which
+AI model assisted, in this format:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION
+```
+
+For example: `Assisted-by: claude-code:claude-opus-4-7` or
+`Assisted-by: github-copilot:MODEL_VERSION`.
+
+This applies to all commits, including those created via automation or agent workflows.
+
+## Commit generation
+
+No commit should be signed-off by an AI agent or OS. Only a human can sign-off their commits
+with their own certificate.
+
+## Branch Naming
+
+- Do not prefix branches with `claude/`, `copilot/`, `codex/`, `cursor/`, `ai/`, `bot/`, or any agent-derived namespace.
+- Do not append auto-generated suffixes (random IDs, timestamps, session hashes) unless genuinely required to disambiguate.
+- Branch names should be explicit and brief about what is being done or asked — e.g. `add-commit-attribution`, `fix-win-hang`, etc.
+- Prefer kebab-case.
+
+## PR description content
+
+The `Assisted-by` attribution should be included in the PR description, but no link to the
+session itself should be included, as it is not publicly accessible.
+
+When a PR fixes an issue or relates to / replaces another issue, the PR description should
+include a reference to the issue number after the main description but before the
+`Assisted-by:` attribution, e.g. `Fixes: #123` or `Closes: #124`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,7 @@
+# Gemini CLI Context
+
+The contribution and commit rules for this repository are maintained as a single source of
+truth in [`AGENTS.md`](./AGENTS.md) at the repository root, shared by every AI coding agent.
+Gemini CLI loads them via the import below.
+
+@./AGENTS.md


### PR DESCRIPTION
## Summary

The contribution and commit rules for this repository had no single home that every AI coding agent reads. This adds **`AGENTS.md`** as the canonical source — the cross-tool standard read natively by Codex, Cursor, the GitHub Copilot coding agent, VS Code, Gemini CLI and many others — so all agents follow the same rules, above all that **every commit is authored by a human** (with an `Assisted-by:` trailer naming the assisting model).

The agents that use a dedicated file load that same single source:

- **`AGENTS.md`** (new) — the canonical rules, in plain Markdown.
- **`.claude/CLAUDE.md`** (new) — imports `@../AGENTS.md` (Claude Code's import syntax); also keeps a hidapi-specific note about attributing GitHub comments posted on a maintainer's behalf.
- **`GEMINI.md`** (new) — imports `@./AGENTS.md` (Gemini CLI defaults to `GEMINI.md`).
- **`.github/copilot-instructions.md`** (new) — points to `AGENTS.md`; the Copilot coding agent and VS Code read `AGENTS.md` natively.

Adapted from libusb/libusb#1842.

Assisted-by: claude-code:claude-opus-4-8
