### PR TITLE
appveyor: derive the build version from the repo

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,9 @@
+# The build version is derived from the repo here, which overrides the
+# hard-coded "Build version format" in the AppVeyor project settings. The
+# {build} placeholder is replaced in before_build with the version read from
+# the VERSION file plus the short commit hash (see below).
+version: '{build}'
+
 environment:
   matrix:
   - BUILD_ENV: msbuild
@@ -5,6 +11,15 @@ environment:
   - BUILD_ENV: msbuild
     arch: Win32
   - BUILD_ENV: cygwin
+
+# Derive the build version from the repo: <VERSION>-<short commit>.<build number>,
+# e.g. 0.16.0-1a2b3c4.42. The build number keeps it unique even if the same
+# commit is built more than once.
+before_build:
+  - ps: |
+      $base  = (Get-Content -Raw "$env:APPVEYOR_BUILD_FOLDER/VERSION").Trim()
+      $short = git rev-parse --short HEAD
+      Update-AppveyorBuild -Version "$base-$short.$env:APPVEYOR_BUILD_NUMBER"
 
 for:
   -


### PR DESCRIPTION
## Summary

The AppVeyor **"Build version format"** is currently hard-coded in the project's web settings. This moves version control into the repo:

- adds `version: '{build}'` to `.appveyor.yml` (a `version:` in the file overrides the UI setting), and
- in a `before_build` step, replaces it with a version derived from the repo — the `VERSION` file + the short commit hash + the build number:

```
0.16.0-1a2b3c4.42
```

`Update-AppveyorBuild` runs after checkout (so the `VERSION` file is available); `APPVEYOR_REPO_COMMIT` provides the commit and `APPVEYOR_BUILD_NUMBER` keeps each build's version unique even if the same commit is built more than once.

Assisted-by: claude-code:claude-opus-4-8
