### PR TITLE
windows: deliver hotplug ENUMERATE pass asynchronously on the event context

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -30,14 +30,6 @@ extern "C" {
 #undef WIN32_LEAN_AND_MEAN
 #endif
 
-/* The native threadpool API (CreateThreadpoolWork & co), used to deliver
- * the HID_API_HOTPLUG_ENUMERATE pass asynchronously, is only declared
- * for Windows Vista and up. */
-#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0600)
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
-#endif
-
 #include "hidapi_winapi.h"
 
 #include <windows.h>
@@ -226,28 +218,67 @@ struct hid_device_ {
 		DWORD write_timeout_ms;
 };
 
+/* The threadpool work item that delivers the HID_API_HOTPLUG_ENUMERATE pass is
+   Windows Vista and up, so - like every other API this file uses above its
+   minimum target - it is resolved dynamically: a static import would raise the
+   Windows version hidapi can be loaded on for every user, including those that
+   never use hotplug. Hotplug registration fails with an error when it is not
+   available; nothing else in the library depends on it.
+
+   The threadpool handles are declared as opaque pointers (which is what they are
+   in the SDK, too), so that none of this needs headers newer than the file's
+   minimum target. */
+typedef VOID (WINAPI *hid_internal_tp_work_callback)(PVOID instance, PVOID context, PVOID work);
+typedef PVOID (WINAPI *CreateThreadpoolWork_)(hid_internal_tp_work_callback callback, PVOID context, PVOID callback_environ);
+typedef VOID (WINAPI *SubmitThreadpoolWork_)(PVOID work);
+typedef VOID (WINAPI *CloseThreadpoolWork_)(PVOID work);
+typedef VOID (WINAPI *WaitForThreadpoolWorkCallbacks_)(PVOID work, BOOL cancel_pending);
+
+static CreateThreadpoolWork_ hid_internal_CreateThreadpoolWork = NULL;
+static SubmitThreadpoolWork_ hid_internal_SubmitThreadpoolWork = NULL;
+static CloseThreadpoolWork_ hid_internal_CloseThreadpoolWork = NULL;
+static WaitForThreadpoolWorkCallbacks_ hid_internal_WaitForThreadpoolWorkCallbacks = NULL;
+
+/* An interface path captured by the registration-time enumeration whose arrival
+   notification may still be in flight. See hid_internal_hotplug_record_pending_arrivals. */
+struct hid_hotplug_path {
+	char *path;
+	struct hid_hotplug_path *next;
+};
+
 static struct hid_hotplug_context {
 	/* Win32 notification handle */
 	HCMNOTIFICATION notify_handle;
 
-	/* Threadpool work item: delivers pending HID_API_HOTPLUG_ENUMERATE
+	/* Threadpool work item (a PTP_WORK): delivers pending HID_API_HOTPLUG_ENUMERATE
 	   passes and performs cleanup deferred from the notification callback.
 	   Created with the first callback registration, closed by hid_exit(). */
-	PTP_WORK event_work;
+	PVOID event_work;
 
 	/* Number of notification handles detached from the context whose
-	   CM_Unregister_Notification call has not completed yet, and the condition
-	   used to wait for that to drop to zero (a zero-initialized
-	   CONDITION_VARIABLE is valid). Guarded by the critical section.
-	   A new notification is only armed once this is zero: the OS keeps a
+	   CM_Unregister_Notification call has not completed yet, and a manual-reset
+	   event that is signaled exactly while that count is zero. Both are guarded
+	   by the critical section (the event is only ever waited on without it).
+	   A new notification is only armed once the count is zero: the OS keeps a
 	   detached handle live until the unregistration completes, and two live
 	   registrations would deliver every event twice. */
 	LONG pending_unregistrations;
-	CONDITION_VARIABLE unregistration_cv;
+	HANDLE quiescent_event;
 
 	/* Set when CM_Unregister_Notification failed: the OS-side registration may
-	   still be live, so the state its callbacks can touch is never destroyed */
+	   still be live and call into this module at any time. Sticky for the whole
+	   process - the state such a notification can reach is never destroyed, the
+	   libraries it calls into are never unloaded, the module is pinned, and no
+	   second notification is ever armed next to it (every event would be
+	   delivered twice). */
+	unsigned char notification_leaked;
+
+	/* Same failure, scoped to the teardown that has to report it (hid_exit) */
 	unsigned char unregistration_failed;
+
+	/* Set while hid_exit() is tearing the machinery down: registration and
+	   deregistration fail instead of re-arming into a context being destroyed */
+	unsigned char exiting;
 
 	/* Critical section (faster mutex substitute), for both cached device list and callback list changes */
 	CRITICAL_SECTION critical_section;
@@ -265,6 +296,10 @@ static struct hid_hotplug_context {
 
 	/* Linked list of the device infos (mandatory when the device is disconnected) */
 	struct hid_device_info *devs;
+
+	/* Paths whose arrival notification may still be in flight while it has
+	   already been reported by the registration-time enumeration */
+	struct hid_hotplug_path *pending_arrivals;
 } hid_hotplug_context; /* zero-initialized (static storage); next_handle set on first init */
 
 static hid_device *new_hid_device()
@@ -312,7 +347,7 @@ static void free_hid_device(hid_device *dev)
 	free(dev);
 }
 
-static void register_winapi_error_to_buffer(wchar_t **error_buffer, const WCHAR *op)
+static void register_winapi_error_code_to_buffer(wchar_t **error_buffer, const WCHAR *op, DWORD error_code)
 {
 	free(*error_buffer);
 	*error_buffer = NULL;
@@ -323,7 +358,6 @@ static void register_winapi_error_to_buffer(wchar_t **error_buffer, const WCHAR 
 	}
 
 	WCHAR system_err_buf[1024];
-	DWORD error_code = GetLastError();
 
 	DWORD system_err_len = FormatMessageW(
 		FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -369,6 +403,15 @@ static void register_winapi_error_to_buffer(wchar_t **error_buffer, const WCHAR 
 	}
 }
 
+static void register_winapi_error_to_buffer(wchar_t **error_buffer, const WCHAR *op)
+{
+	/* Capture the error code first: free() (and, for the global error buffer,
+	   acquiring its lock) is not required to preserve it */
+	DWORD error_code = GetLastError();
+
+	register_winapi_error_code_to_buffer(error_buffer, op, error_code);
+}
+
 #if defined(__GNUC__)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Warray-bounds"
@@ -402,24 +445,54 @@ static void register_string_error(hid_device *dev, const WCHAR *string_error)
 	register_string_error_to_buffer(&dev->last_error_str, string_error);
 }
 
+/* A minimal exclusive lock that needs no initialization.
+
+   Deliberately not an SRWLOCK (nor a CONDITION_VARIABLE, nor the CRITICAL_SECTION
+   that cannot be initialized statically): those APIs are Windows Vista and up, so
+   using them would turn hidapi into a load-time importer of Vista-only kernel32
+   symbols - for every user of the library, including those that never touch
+   hotplug. Everything this file uses above its minimum target is resolved
+   dynamically instead (see lookup_functions and hid_internal_hotplug_resolve_threadpool).
+   The regions guarded by this lock are a handful of instructions long. */
+typedef volatile LONG hid_internal_lock;
+
+static void hid_internal_lock_acquire(hid_internal_lock *lock)
+{
+	while (InterlockedCompareExchange(lock, 1, 0) != 0) {
+		/* The holder is never descheduled for long: yield and retry */
+		Sleep(0);
+	}
+}
+
+static void hid_internal_lock_release(hid_internal_lock *lock)
+{
+	InterlockedExchange(lock, 0);
+}
+
 static wchar_t *last_global_error_str = NULL;
 
 /* Serializes mutations of last_global_error_str: the hotplug API is
-   thread-safe and its failure paths may write the global error concurrently */
-static SRWLOCK global_error_lock = SRWLOCK_INIT;
+   thread-safe and its failure paths may write the global error concurrently.
+   Note that this only protects writers against each other: HIDAPI's internal
+   event context must never write the global error at all, because hid_error(NULL)
+   hands the raw string pointer out to the application without any lock. */
+static hid_internal_lock global_error_lock = 0;
 
 static void register_global_winapi_error(const WCHAR *op)
 {
-	AcquireSRWLockExclusive(&global_error_lock);
-	register_winapi_error_to_buffer(&last_global_error_str, op);
-	ReleaseSRWLockExclusive(&global_error_lock);
+	/* Capture the error code before the lock: acquiring it may clobber it */
+	DWORD error_code = GetLastError();
+
+	hid_internal_lock_acquire(&global_error_lock);
+	register_winapi_error_code_to_buffer(&last_global_error_str, op, error_code);
+	hid_internal_lock_release(&global_error_lock);
 }
 
 static void register_global_error(const WCHAR *string_error)
 {
-	AcquireSRWLockExclusive(&global_error_lock);
+	hid_internal_lock_acquire(&global_error_lock);
 	register_string_error_to_buffer(&last_global_error_str, string_error);
-	ReleaseSRWLockExclusive(&global_error_lock);
+	hid_internal_lock_release(&global_error_lock);
 }
 
 static HANDLE open_device(const wchar_t *path, BOOL open_rw)
@@ -450,24 +523,98 @@ HID_API_EXPORT const char* HID_API_CALL hid_version_str(void)
 }
 
 /* Serializes the bootstrap of the hotplug machinery: two racing first
-   registrations must not both initialize the critical section */
-static SRWLOCK hotplug_init_lock = SRWLOCK_INIT;
+   registrations must not both initialize the critical section, and every read of
+   mutex_ready that is not already made under the critical section is made under
+   this lock (it is what publishes the critical section to other threads). */
+static hid_internal_lock hotplug_init_lock = 0;
 
-static void hid_internal_hotplug_init()
+/* Resolves the threadpool API used as the hotplug event context.
+   Always called inside the critical section. Returns -1 when it is unavailable
+   (the OS predates it), in which case hotplug is not available either. */
+static int hid_internal_hotplug_resolve_threadpool(void)
 {
-	AcquireSRWLockExclusive(&hotplug_init_lock);
-	if (!hid_hotplug_context.mutex_ready) {
-		InitializeCriticalSection(&hid_hotplug_context.critical_section);
+	HMODULE kernel32;
 
-		/* Set state to Ready */
-		hid_hotplug_context.mutex_ready = 1;
-		hid_hotplug_context.mutex_in_use = 0;
-		hid_hotplug_context.cb_list_dirty = 0;
-		hid_hotplug_context.pending_unregistrations = 0;
-		if (hid_hotplug_context.next_handle < FIRST_HOTPLUG_CALLBACK_HANDLE)
-			hid_hotplug_context.next_handle = FIRST_HOTPLUG_CALLBACK_HANDLE;
+	if (hid_internal_CreateThreadpoolWork != NULL) {
+		/* Already resolved: resolved last, so it doubles as the "all set" flag */
+		return 0;
 	}
-	ReleaseSRWLockExclusive(&hotplug_init_lock);
+
+	/* kernel32.dll is mapped into every process and is never unloaded, so its
+	   handle needs neither LoadLibrary nor FreeLibrary */
+	kernel32 = GetModuleHandleW(L"kernel32.dll");
+	if (kernel32 == NULL) {
+		return -1;
+	}
+
+/* Avoid direct function-pointer cast from FARPROC to typed callback pointer.
+   Using memcpy keeps this warning-free regardless of the compiler and compiler settings. */
+#define RESOLVE_TP(x) do { \
+	FARPROC proc_addr = GetProcAddress(kernel32, #x); \
+	if (!proc_addr) return -1; \
+	memcpy(&hid_internal_##x, &proc_addr, sizeof(hid_internal_##x)); \
+} while (0)
+
+	RESOLVE_TP(SubmitThreadpoolWork);
+	RESOLVE_TP(CloseThreadpoolWork);
+	RESOLVE_TP(WaitForThreadpoolWorkCallbacks);
+	RESOLVE_TP(CreateThreadpoolWork);
+
+#undef RESOLVE_TP
+
+	return 0;
+}
+
+/* Bootstraps the hotplug machinery. The critical section and the quiescence event
+   are created once and are NEVER destroyed: they are the only things that can
+   serialize against a notification callback, and no caller - hid_exit() included -
+   can prove that no callback is about to enter them. Keeping them for the process
+   lifetime costs one critical section and one event handle, and removes an entire
+   class of use-after-free (a callback, a threadpool work item or a concurrent
+   deregistration entering a deleted critical section).
+   Returns -1 if the machinery cannot be initialized. */
+static int hid_internal_hotplug_init(void)
+{
+	int result = 0;
+
+	hid_internal_lock_acquire(&hotplug_init_lock);
+	if (!hid_hotplug_context.mutex_ready) {
+		/* Manual reset, initially signaled: nothing is pending yet */
+		hid_hotplug_context.quiescent_event = CreateEvent(NULL, TRUE, TRUE, NULL);
+		if (hid_hotplug_context.quiescent_event == NULL) {
+			register_global_winapi_error(L"hid_hotplug_register_callback/CreateEvent");
+			result = -1;
+		} else {
+			InitializeCriticalSection(&hid_hotplug_context.critical_section);
+
+			hid_hotplug_context.mutex_in_use = 0;
+			hid_hotplug_context.cb_list_dirty = 0;
+			hid_hotplug_context.pending_unregistrations = 0;
+			if (hid_hotplug_context.next_handle < FIRST_HOTPLUG_CALLBACK_HANDLE)
+				hid_hotplug_context.next_handle = FIRST_HOTPLUG_CALLBACK_HANDLE;
+
+			/* Set state to Ready. Published last: a thread that observes this
+			   under hotplug_init_lock also observes everything above. */
+			hid_hotplug_context.mutex_ready = 1;
+		}
+	}
+	hid_internal_lock_release(&hotplug_init_lock);
+
+	return result;
+}
+
+/* Whether the critical section exists and may be entered. Once it does, it stays
+   valid for the process lifetime (see hid_internal_hotplug_init), so the answer
+   can never go stale between the check and the EnterCriticalSection. */
+static int hid_internal_hotplug_ready(void)
+{
+	int ready;
+
+	hid_internal_lock_acquire(&hotplug_init_lock);
+	ready = hid_hotplug_context.mutex_ready;
+	hid_internal_lock_release(&hotplug_init_lock);
+
+	return ready;
 }
 
 int HID_API_EXPORT hid_init(void)
@@ -530,6 +677,108 @@ static struct hid_device_info *hid_internal_copy_device_info(const struct hid_de
 	return dst;
 }
 
+/* Pins the module this code lives in, so that it stays mapped even if the
+   application unloads hidapi: a notification that could not be unregistered is
+   still live at the OS level and will call hid_internal_notify_callback.
+   Any address inside the module identifies it; hid_hotplug_context is in the very
+   same translation unit as the callback. */
+static void hid_internal_hotplug_pin_module(void)
+{
+	HMODULE module = NULL;
+
+	GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+		(LPCWSTR)(void *)&hid_hotplug_context, &module);
+}
+
+/* Always called inside a locked mutex */
+static void hid_internal_hotplug_free_pending_arrivals(void)
+{
+	struct hid_hotplug_path *current = hid_hotplug_context.pending_arrivals;
+
+	hid_hotplug_context.pending_arrivals = NULL;
+
+	while (current != NULL) {
+		struct hid_hotplug_path *next = current->next;
+		free(current->path);
+		free(current);
+		current = next;
+	}
+}
+
+/* Records the interface paths the registration-time enumeration has just captured.
+   Always called inside a locked mutex; returns -1 on allocation failure.
+
+   The notification is armed BEFORE the enumeration runs (a device connecting in
+   between must not be missed by both), so a device that arrives in that window is
+   picked up by the enumeration AND has an arrival notification in flight. That
+   notification must not report - or cache - the same connection a second time.
+
+   This window is the only place where a duplicate arrival can occur, so the
+   suppression is scoped to it: a recorded path swallows at most one arrival and is
+   dropped as soon as the device leaves. Outside of it, an arrival for a path that
+   is still cached is NOT a duplicate: an interface path is reused when a device is
+   replugged into the same port, so suppressing it would swallow a real connection. */
+static int hid_internal_hotplug_record_pending_arrivals(void)
+{
+	for (struct hid_device_info *device = hid_hotplug_context.devs; device != NULL; device = device->next) {
+		struct hid_hotplug_path *entry = (struct hid_hotplug_path *)calloc(1, sizeof(struct hid_hotplug_path));
+
+		if (entry == NULL) {
+			return -1;
+		}
+
+		/* Cached devices always have a path (hid_internal_get_device_info fails without one) */
+		entry->path = _strdup(device->path);
+		if (entry->path == NULL) {
+			free(entry);
+			return -1;
+		}
+
+		entry->next = hid_hotplug_context.pending_arrivals;
+		hid_hotplug_context.pending_arrivals = entry;
+	}
+
+	return 0;
+}
+
+/* Consumes the pending-arrival record for this path, if there is one.
+   Always called inside a locked mutex.
+   Returns 1 when this arrival was already reported by the registration-time
+   enumeration (see hid_internal_hotplug_record_pending_arrivals) and must be
+   dropped, 0 when it is a genuine new connection. */
+static int hid_internal_hotplug_take_pending_arrival(const char *path)
+{
+	for (struct hid_hotplug_path **current = &hid_hotplug_context.pending_arrivals; *current != NULL; current = &(*current)->next) {
+		/* Case-independent path comparison is mandatory */
+		if (_stricmp((*current)->path, path) == 0) {
+			struct hid_hotplug_path *entry = *current;
+			*current = entry->next;
+			free(entry->path);
+			free(entry);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+/* Unlinks the cached device with this path, if there is one, and hands it to the
+   caller (who owns it). Always called inside a locked mutex. */
+static struct hid_device_info *hid_internal_hotplug_take_cached_device(const char *path)
+{
+	for (struct hid_device_info **current = &hid_hotplug_context.devs; *current != NULL; current = &(*current)->next) {
+		/* Case-independent path comparison is mandatory */
+		if ((*current)->path != NULL && _stricmp((*current)->path, path) == 0) {
+			struct hid_device_info *device = *current;
+			*current = device->next;
+			device->next = NULL;
+			return device;
+		}
+	}
+
+	return NULL;
+}
+
 static void hid_internal_hotplug_remove_postponed()
 {
 	/* Unregister the callbacks whose removal was postponed */
@@ -572,18 +821,45 @@ static void hid_internal_hotplug_finish_unregistration(HCMNOTIFICATION notify_ha
 
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 	if (cr != CR_SUCCESS) {
-		/* The OS-side registration may still be live: taint the epoch so
-		   hid_exit() never destroys the state a late notification can touch */
+		/* The OS-side registration may still be live and call into this module at
+		   any time. Everything it can reach has to survive: the critical section and
+		   the quiescence event are never destroyed anyway, the resolved libraries are
+		   never unloaded (see hid_exit), the module is pinned, and no second
+		   notification is ever armed next to this one - the two would deliver every
+		   event twice. hid_exit() reports the failure; this function also runs on the
+		   internal event context, which must never touch the global error string (an
+		   application thread may be reading it through hid_error(NULL)). */
+		hid_hotplug_context.notification_leaked = 1;
 		hid_hotplug_context.unregistration_failed = 1;
+		hid_internal_hotplug_pin_module();
 	}
 	hid_hotplug_context.pending_unregistrations--;
 	if (hid_hotplug_context.pending_unregistrations == 0) {
-		WakeAllConditionVariable(&hid_hotplug_context.unregistration_cv);
+		SetEvent(hid_hotplug_context.quiescent_event);
 	}
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+}
 
-	if (cr != CR_SUCCESS) {
-		register_global_error(L"CM_Unregister_Notification failed for Hotplug notification");
+/* Waits until every detached notification handle has been unregistered.
+   Must be called WITHOUT the critical section: the unregistration completes on
+   another thread, which needs it. */
+static void hid_internal_hotplug_wait_quiescent(void)
+{
+	for (;;) {
+		int pending;
+
+		EnterCriticalSection(&hid_hotplug_context.critical_section);
+		pending = (hid_hotplug_context.pending_unregistrations > 0);
+		LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+		if (!pending) {
+			return;
+		}
+
+		if (WaitForSingleObject(hid_hotplug_context.quiescent_event, INFINITE) == WAIT_FAILED) {
+			/* Should never happen; do not spin forever on a broken event */
+			return;
+		}
 	}
 }
 
@@ -615,11 +891,14 @@ static HCMNOTIFICATION hid_internal_hotplug_cleanup()
 		hid_hotplug_context.devs = NULL;
 	}
 
+	hid_internal_hotplug_free_pending_arrivals();
+
 	notify_handle = hid_hotplug_context.notify_handle;
 	hid_hotplug_context.notify_handle = NULL;
 	if (notify_handle != NULL) {
 		/* Balanced by hid_internal_hotplug_finish_unregistration */
 		hid_hotplug_context.pending_unregistrations++;
+		ResetEvent(hid_hotplug_context.quiescent_event);
 	}
 	return notify_handle;
 }
@@ -655,7 +934,7 @@ static void hid_internal_hotplug_replay_flush(struct hid_hotplug_callback *callb
 /* Threadpool work item: delivers pending HID_API_HOTPLUG_ENUMERATE passes
    (unless a live event got to them first) and performs the cleanup the
    notification callback is not allowed to perform itself. */
-static VOID CALLBACK hid_internal_hotplug_event_work(PTP_CALLBACK_INSTANCE instance, PVOID context, PTP_WORK work)
+static VOID WINAPI hid_internal_hotplug_event_work(PVOID instance, PVOID context, PVOID work)
 {
 	HCMNOTIFICATION notify_handle;
 
@@ -678,23 +957,69 @@ static VOID CALLBACK hid_internal_hotplug_event_work(PTP_CALLBACK_INSTANCE insta
 	hid_internal_hotplug_finish_unregistration(notify_handle);
 }
 
-static int hid_internal_hotplug_exit()
+/* Whether a notification could not be unregistered at some point in this process
+   and may still be live at the OS level. Sticky: see hid_hotplug_context. */
+static int hid_internal_hotplug_notification_leaked(void)
 {
-	HCMNOTIFICATION notify_handle;
-	int failed_epoch;
+	int leaked;
 
-	if (!hid_hotplug_context.mutex_ready) {
-		/* If the critical section is not initialized, we are safe to assume nothing else is */
+	if (!hid_internal_hotplug_ready()) {
 		return 0;
 	}
+
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
-	struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
+	leaked = (hid_hotplug_context.notification_leaked != 0);
+	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+	return leaked;
+}
+
+/* Ends the teardown started by hid_internal_hotplug_exit: see the `exiting` flag.
+   Called by hid_exit() once the resolved libraries are gone, too. */
+static void hid_internal_hotplug_exit_done(void)
+{
+	if (!hid_internal_hotplug_ready()) {
+		return;
+	}
+
+	EnterCriticalSection(&hid_hotplug_context.critical_section);
+	hid_hotplug_context.exiting = 0;
+	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+}
+
+static int hid_internal_hotplug_exit(void)
+{
+	HCMNOTIFICATION notify_handle;
+	PVOID event_work;
+	int failed;
+
+	/* Not a no-op even when hotplug was never used: `exiting` is what keeps a
+	   concurrent hid_hotplug_register_callback() - which is thread-safe, and
+	   initializes the library implicitly - from calling into hid.dll/cfgmgr32.dll
+	   while hid_exit() is unloading them. It needs the critical section to be there. */
+	if (hid_internal_hotplug_init() < 0) {
+		/* Nothing can be armed if the machinery cannot even be initialized */
+		return 0;
+	}
+
+	EnterCriticalSection(&hid_hotplug_context.critical_section);
+
+	/* Nothing may arm the machinery from here on. Without this, a registration
+	   waiting for a pending unregistration to complete could wake up behind this
+	   teardown, arm a fresh notification and append a callback to a context that
+	   is being dismantled - leaving a live notification and a "registered"
+	   callback behind hid_exit(). */
+	hid_hotplug_context.exiting = 1;
+
 	/* Remove all callbacks from the list, including their undelivered HID_API_HOTPLUG_ENUMERATE snapshots */
-	while (*current) {
-		struct hid_hotplug_callback *next = (*current)->next;
-		hid_free_enumeration((*current)->replay);
-		free(*current);
-		*current = next;
+	{
+		struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
+		while (*current) {
+			struct hid_hotplug_callback *next = (*current)->next;
+			hid_free_enumeration((*current)->replay);
+			free(*current);
+			*current = next;
+		}
 	}
 	notify_handle = hid_internal_hotplug_cleanup();
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
@@ -702,62 +1027,92 @@ static int hid_internal_hotplug_exit()
 	hid_internal_hotplug_finish_unregistration(notify_handle);
 
 	/* Quiescence: unregistrations started by concurrent (contract-legal)
-	   hid_hotplug_deregister_callback calls must complete before the state
-	   their notifications can still touch is destroyed. The sleep releases
-	   the critical section while waiting. */
+	   hid_hotplug_deregister_callback calls must complete before anything a
+	   notification can still reach is released */
+	hid_internal_hotplug_wait_quiescent();
+
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
-	while (hid_hotplug_context.pending_unregistrations > 0) {
-		if (!SleepConditionVariableCS(&hid_hotplug_context.unregistration_cv, &hid_hotplug_context.critical_section, INFINITE)) {
-			/* Should never happen; treat like a failed unregistration rather than spinning */
-			break;
-		}
+	if (hid_hotplug_context.pending_unregistrations > 0) {
+		/* Only reachable if waiting itself failed: treat it as a live notification */
+		hid_hotplug_context.notification_leaked = 1;
+		hid_hotplug_context.unregistration_failed = 1;
+		hid_internal_hotplug_pin_module();
 	}
-	failed_epoch = (hid_hotplug_context.unregistration_failed != 0) || (hid_hotplug_context.pending_unregistrations > 0);
+	/* Scoped to this teardown: a later hid_exit() has nothing of its own to report
+	   (a hotplug callback can no longer be registered once a notification leaked) */
+	failed = (hid_hotplug_context.unregistration_failed != 0);
+	hid_hotplug_context.unregistration_failed = 0;
+
+	event_work = hid_hotplug_context.event_work;
+	if (!failed && !hid_hotplug_context.notification_leaked) {
+		hid_hotplug_context.event_work = NULL;
+	} else {
+		/* A notification may still fire and submit to the work item: keep it
+		   (deliberately leaked), along with the critical section and the device
+		   cache it works on */
+		event_work = NULL;
+	}
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
-	if (failed_epoch) {
-		/* At least one notification may still be live at the OS level: keep the
-		   critical section and the work item alive (deliberately leaked), so a
-		   late callback touches valid, empty state instead of freed memory */
+	if (event_work != NULL) {
+		/* No notification is registered anymore (CM_Unregister_Notification only
+		   returns once its callbacks have finished) and nothing can submit new work
+		   while `exiting` is set, so the work item can be drained and closed.
+		   Not under the critical section: the work item takes it.
+		   hid_exit() must not be called from a hotplug callback, so the wait cannot
+		   deadlock on the calling thread itself. */
+		hid_internal_WaitForThreadpoolWorkCallbacks(event_work, FALSE);
+		hid_internal_CloseThreadpoolWork(event_work);
+	}
+
+	EnterCriticalSection(&hid_hotplug_context.critical_section);
+	/* A last-gasp notification callback may have re-added a device between the
+	   cleanup and the completion of the unregistration */
+	hid_free_enumeration(hid_hotplug_context.devs);
+	hid_hotplug_context.devs = NULL;
+	hid_internal_hotplug_free_pending_arrivals();
+	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+	/* `exiting` stays set until hid_exit() is done unloading the libraries:
+	   see hid_internal_hotplug_exit_done.
+	   The critical section and the quiescence event are kept for the process
+	   lifetime on purpose: see hid_internal_hotplug_init */
+
+	if (failed) {
 		register_global_error(L"hid_exit: a hotplug notification could not be unregistered");
 		return -1;
 	}
-
-	if (hid_hotplug_context.event_work) {
-		/* Wait for any in-flight work item before the critical section goes away.
-		   hid_exit() must not be called from a callback, so this cannot deadlock. */
-		WaitForThreadpoolWorkCallbacks(hid_hotplug_context.event_work, FALSE);
-		CloseThreadpoolWork(hid_hotplug_context.event_work);
-		hid_hotplug_context.event_work = NULL;
-	}
-
-	/* A last-gasp notification callback may have re-added a device between
-	   the cleanup and the unregistration; nothing can race us anymore here */
-	if (hid_hotplug_context.devs != NULL) {
-		hid_free_enumeration(hid_hotplug_context.devs);
-		hid_hotplug_context.devs = NULL;
-	}
-
-	hid_hotplug_context.mutex_ready = 0;
-	DeleteCriticalSection(&hid_hotplug_context.critical_section);
 
 	return 0;
 }
 
 int HID_API_EXPORT hid_exit(void)
 {
-	if (hid_internal_hotplug_exit() < 0) {
-		/* A hotplug notification could not be unregistered and may still fire:
-		   keep the resolved DLLs loaded (deliberately leaked) so a late
-		   callback does not call into unloaded code.
-		   register_global_error: set by hid_internal_hotplug_exit */
+	int result = hid_internal_hotplug_exit();
+
+#ifndef HIDAPI_USE_DDK
+	if (!hid_internal_hotplug_notification_leaked()) {
+		/* Still under `exiting`: a concurrent (thread-safe) hotplug registration
+		   fails instead of calling into libraries that are being unloaded here.
+		   Every other call that goes through them either holds the critical section
+		   or is accounted for by pending_unregistrations, which the teardown above
+		   has already waited out. */
+		free_library_handles();
+		hidapi_initialized = FALSE;
+	}
+	/* else: a hotplug notification is still registered at the OS level and its
+	   callback calls into hid.dll/cfgmgr32.dll through these handles: they stay
+	   loaded (deliberately leaked, and the module is pinned) so that a late
+	   notification never calls into unloaded code */
+#endif
+
+	hid_internal_hotplug_exit_done();
+
+	if (result < 0) {
+		/* register_global_error: set by hid_internal_hotplug_exit */
 		return -1;
 	}
 
-#ifndef HIDAPI_USE_DDK
-	free_library_handles();
-	hidapi_initialized = FALSE;
-#endif
 	register_global_error(NULL);
 
 	return 0;
@@ -1118,6 +1473,12 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 	/* Fill out the record */
 	dev->next = NULL;
 	dev->path = hid_internal_UTF16toUTF8(path);
+	if (dev->path == NULL) {
+		/* A record without a path is useless to the caller and unusable as the key
+		   of the hotplug device cache (where it would crash the removal lookup) */
+		free(dev);
+		return NULL;
+	}
 	dev->interface_number = -1;
 
 	attrib.Size = sizeof(HIDD_ATTRIBUTES);
@@ -1162,6 +1523,13 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 	string[0] = L'\0';
 	HidD_GetProductString(handle, string, size);
 	dev->product_string = _wcsdup(string);
+
+	if (dev->serial_number == NULL || dev->manufacturer_string == NULL || dev->product_string == NULL) {
+		/* Out of memory. A half-built record is not a device (and the bus-specific
+		   fixups right below dereference these strings) */
+		hid_free_enumeration(dev);
+		return NULL;
+	}
 
 	/* now, the portion that depends on string descriptors */
 	switch (dev->bus_type) {
@@ -1265,7 +1633,16 @@ static struct hid_device_info *hid_internal_enumerate(unsigned short vendor_id, 
 			struct hid_device_info *tmp = hid_internal_get_device_info(device_interface, device_handle);
 
 			if (tmp == NULL) {
-				goto cont_close;
+				/* Out of memory. Report a failure rather than a partial list: a
+				   list that silently misses devices is indistinguishable from the
+				   system not having them, and the hotplug device cache and the
+				   HID_API_HOTPLUG_ENUMERATE snapshot are built from it. */
+				register_global_error(L"Failed to allocate memory for a device info");
+				*failure = 1;
+				CloseHandle(device_handle);
+				hid_free_enumeration(root);
+				root = NULL;
+				goto end_of_function;
 			}
 
 			if (cur_dev) {
@@ -1333,35 +1710,33 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
 	if (action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL) {
-		char *path;
-		int known = 0;
+		char *path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink);
 
 		hotplug_event = HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED;
 
-		/* An arrival for a path already in the cache is a duplicate: the
-		   registration-time enumeration overlaps with the already-armed
-		   notification, and a notification being unregistered may briefly
-		   coexist with its replacement. Deduplicating here keeps each
-		   connection reported (and cached) exactly once. */
-		path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink);
-		if (path != NULL) {
-			for (struct hid_device_info *current = hid_hotplug_context.devs; current != NULL; current = current->next) {
-				/* Case-independent path comparison is mandatory */
-				if (current->path != NULL && _stricmp(current->path, path) == 0) {
-					known = 1;
-					break;
-				}
-			}
-			free(path);
-		}
-
-		if (!known) {
+		if (path == NULL) {
+			/* Out of memory: there is nothing to report the connection with, and
+			   nothing is cached, so the cache stays consistent */
+		} else if (hid_internal_hotplug_take_pending_arrival(path)) {
+			/* Already reported (and cached) by the registration-time enumeration:
+			   see hid_internal_hotplug_record_pending_arrivals */
+		} else {
 			/* Open read-only handle to the device */
 			HANDLE read_handle = open_device(event_data->u.DeviceInterface.SymbolicLink, FALSE);
 
 			/* Check validity of read_handle. */
 			if (read_handle != INVALID_HANDLE_VALUE) {
 				device = hid_internal_get_device_info(event_data->u.DeviceInterface.SymbolicLink, read_handle);
+				CloseHandle(read_handle);
+			}
+
+			if (device != NULL) {
+				/* An interface path is reused when a device is replugged into the
+				   same port, so an arrival for a path that is still cached means the
+				   removal of the previous connection was missed. Drop the stale record
+				   instead of shadowing it: a second record for the same path would
+				   never be removed, and the connection is reported as the new one it is. */
+				hid_free_enumeration(hid_internal_hotplug_take_cached_device(device->path));
 
 				/* Append to the end of the device list */
 				if (hid_hotplug_context.devs != NULL) {
@@ -1373,10 +1748,17 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 				} else {
 					hid_hotplug_context.devs = device;
 				}
-
-				CloseHandle(read_handle);
 			}
+			/* else: the interface could not be opened or described. The usual cause
+			   is that it disconnected again before we got to it - no connection is
+			   owed then: nothing is cached, so the removal notification that follows
+			   finds nothing and reports nothing either, which is consistent. An
+			   out-of-memory failure does lose the connection, but there is nothing to
+			   report it with; the cache is left consistent either way, as only fully
+			   described devices are ever cached. */
 		}
+
+		free(path);
 	} else if (action == CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL) {
 		char *path;
 
@@ -1385,17 +1767,12 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 		path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink);
 
 		if (path != NULL) {
+			/* The device is gone: a later arrival on the same path is a new
+			   connection and must not be mistaken for a pending duplicate */
+			hid_internal_hotplug_take_pending_arrival(path);
+
 			/* Get and remove this device from the device list */
-			for (struct hid_device_info **current = &hid_hotplug_context.devs; *current; current = &(*current)->next) {
-				/* Case-independent path comparison is mandatory */
-				if (_stricmp((*current)->path, path) == 0) {
-					struct hid_device_info *next = (*current)->next;
-					device = *current;
-					device->next = NULL;
-					*current = next;
-					break;
-				}
-			}
+			device = hid_internal_hotplug_take_cached_device(path);
 
 			free(path);
 		}
@@ -1448,7 +1825,7 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 		   notification from its own callback is not allowed (deadlock) */
 		hid_internal_hotplug_remove_postponed();
 		if (hid_hotplug_context.hotplug_cbs == NULL && hid_hotplug_context.event_work != NULL) {
-			SubmitThreadpoolWork(hid_hotplug_context.event_work);
+			hid_internal_SubmitThreadpoolWork(hid_hotplug_context.event_work);
 		}
 	}
 
@@ -1498,33 +1875,65 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	hotplug_cb->replay = NULL;
 
 	/* Ensure we are ready to actually use the mutex */
-	hid_internal_hotplug_init();
+	if (hid_internal_hotplug_init() < 0) {
+		/* register_global_error: set by hid_internal_hotplug_init */
+		free(hotplug_cb);
+		return -1;
+	}
 
 	/* Lock the mutex to avoid race conditions */
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
-	/* Handle values are never reused while the library remains initialized */
-	if (hid_hotplug_context.next_handle >= INT_MAX) {
+	for (;;) {
+		if (hid_hotplug_context.exiting) {
+			/* hid_exit() is tearing the machinery down: arming it again behind its
+			   back would leave a live notification and a registered callback with no
+			   context to run in */
+			register_global_error(L"hid_exit() is in progress");
+			LeaveCriticalSection(&hid_hotplug_context.critical_section);
+			free(hotplug_cb);
+			return -1;
+		}
+
+		/* A notification detached by a concurrent deregistration may still be live
+		   at the OS until its unregistration completes; arming a replacement in
+		   that window would deliver every event twice. */
+		if (hid_hotplug_context.hotplug_cbs != NULL || hid_hotplug_context.notify_handle != NULL
+		    || hid_hotplug_context.pending_unregistrations == 0) {
+			break;
+		}
+
+		/* The unregistration completes on another thread (or on the event context),
+		   which needs the critical section, so the wait must not hold it. On wake the
+		   state is re-evaluated from scratch. */
+		LeaveCriticalSection(&hid_hotplug_context.critical_section);
+		if (WaitForSingleObject(hid_hotplug_context.quiescent_event, INFINITE) == WAIT_FAILED) {
+			register_global_winapi_error(L"hid_hotplug_register_callback/WaitForSingleObject");
+			free(hotplug_cb);
+			return -1;
+		}
+		EnterCriticalSection(&hid_hotplug_context.critical_section);
+	}
+
+	if (hid_hotplug_context.notification_leaked) {
+		/* A notification could not be unregistered and may still be live at the OS
+		   level: a second one would deliver every event twice, to every callback.
+		   The condition is sticky (and unreachable in practice), so hotplug stays
+		   unavailable for the rest of the process. */
+		register_global_error(L"A hotplug notification could not be unregistered: hotplug is no longer available");
 		LeaveCriticalSection(&hid_hotplug_context.critical_section);
 		free(hotplug_cb);
+		return -1;
+	}
+
+	/* Handle values are never reused while the library remains initialized */
+	if (hid_hotplug_context.next_handle >= INT_MAX) {
 		register_global_error(L"Hotplug callback handles exhausted");
+		LeaveCriticalSection(&hid_hotplug_context.critical_section);
+		free(hotplug_cb);
 		return -1;
 	}
 	hotplug_cb->handle = hid_hotplug_context.next_handle++;
-
-	/* A notification detached by a concurrent deregistration may still be live
-	   at the OS until its unregistration completes; arming a replacement in
-	   that window would deliver every event twice. The sleep releases the
-	   critical section, so on wake the state is re-evaluated from scratch. */
-	while (hid_hotplug_context.hotplug_cbs == NULL && hid_hotplug_context.notify_handle == NULL
-	       && hid_hotplug_context.pending_unregistrations > 0) {
-		if (!SleepConditionVariableCS(&hid_hotplug_context.unregistration_cv, &hid_hotplug_context.critical_section, INFINITE)) {
-			LeaveCriticalSection(&hid_hotplug_context.critical_section);
-			free(hotplug_cb);
-			register_global_winapi_error(L"hid_hotplug_register_callback/SleepConditionVariableCS");
-			return -1;
-		}
-	}
 
 	/* Start the machinery with the first callback */
 	if (hid_hotplug_context.hotplug_cbs == NULL) {
@@ -1535,12 +1944,19 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 			return -1;
 		}
 
+		if (hid_internal_hotplug_resolve_threadpool() < 0) {
+			register_global_error(L"Hotplug is not supported: the threadpool API is unavailable");
+			LeaveCriticalSection(&hid_hotplug_context.critical_section);
+			free(hotplug_cb);
+			return -1;
+		}
+
 		if (hid_hotplug_context.event_work == NULL) {
-			hid_hotplug_context.event_work = CreateThreadpoolWork(hid_internal_hotplug_event_work, NULL, NULL);
+			hid_hotplug_context.event_work = hid_internal_CreateThreadpoolWork(hid_internal_hotplug_event_work, NULL, NULL);
 			if (hid_hotplug_context.event_work == NULL) {
+				register_global_winapi_error(L"hid_hotplug_register_callback/CreateThreadpoolWork");
 				LeaveCriticalSection(&hid_hotplug_context.critical_section);
 				free(hotplug_cb);
-				register_global_winapi_error(L"hid_hotplug_register_callback/CreateThreadpoolWork");
 				return -1;
 			}
 		}
@@ -1561,36 +1977,39 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 			notify_filter.u.DeviceInterface.ClassGuid = interface_class_guid;
 
 			/* Register for a HID device notification when adding the first callback.
-			   Armed BEFORE the device cache is filled: a device connecting in
-			   between is then caught by the notification and deduplicated against
-			   the cache, instead of being missed by both. */
+			   Armed BEFORE the device cache is filled: a device connecting in between
+			   is then caught by the notification instead of being missed by both, and
+			   the duplicate that this creates is suppressed exactly once
+			   (see hid_internal_hotplug_record_pending_arrivals). */
 			if (CM_Register_Notification(&notify_filter, NULL, hid_internal_notify_callback, &hid_hotplug_context.notify_handle) != CR_SUCCESS) {
+				register_global_error(L"hid_hotplug_register_callback/CM_Register_Notification");
 				hid_hotplug_context.notify_handle = NULL;
 				LeaveCriticalSection(&hid_hotplug_context.critical_section);
 				free(hotplug_cb);
-				register_global_error(L"hid_hotplug_register_callback/CM_Register_Notification");
 				return -1;
 			}
 
-			/* Normally NULL already; an old notification may have appended
-			   entries between its detachment and the completion of its
-			   unregistration (or, after a failed unregistration, at any time) */
-			if (hid_hotplug_context.devs != NULL) {
-				hid_free_enumeration(hid_hotplug_context.devs);
-				hid_hotplug_context.devs = NULL;
-			}
+			/* Normally empty already; an old notification may have appended entries
+			   between its detachment and the completion of its unregistration */
+			hid_free_enumeration(hid_hotplug_context.devs);
+			hid_hotplug_context.devs = NULL;
+			hid_internal_hotplug_free_pending_arrivals();
 
 			/* Fill already connected devices so we can use this info in disconnection
 			   notifications and HID_API_HOTPLUG_ENUMERATE passes */
 			hid_hotplug_context.devs = hid_internal_enumerate(0, 0, &enumerate_failure);
+			if (!enumerate_failure && hid_internal_hotplug_record_pending_arrivals() < 0) {
+				register_global_error(L"Failed to allocate memory for the hotplug device cache");
+				enumerate_failure = 1;
+			}
 			if (enumerate_failure) {
 				/* An empty system is fine; a failed enumeration is not: the device
-				   cache and the ENUMERATE snapshot would misrepresent the system */
+				   cache and the ENUMERATE snapshot would misrepresent the system.
+				   register_global_error: set above or by hid_internal_enumerate */
 				HCMNOTIFICATION notify_handle = hid_internal_hotplug_cleanup();
 				LeaveCriticalSection(&hid_hotplug_context.critical_section);
 				hid_internal_hotplug_finish_unregistration(notify_handle);
 				free(hotplug_cb);
-				/* register_global_error: set by hid_internal_enumerate */
 				return -1;
 			}
 		}
@@ -1609,13 +2028,13 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 			*replay_tail = hid_internal_copy_device_info(device);
 			if (*replay_tail == NULL) {
 				HCMNOTIFICATION notify_handle;
+				register_global_error(L"Failed to allocate memory for a device info snapshot");
 				hid_free_enumeration(hotplug_cb->replay);
 				/* Tear the machinery down if this would-be-first callback was starting it */
 				notify_handle = hid_internal_hotplug_cleanup();
 				LeaveCriticalSection(&hid_hotplug_context.critical_section);
 				hid_internal_hotplug_finish_unregistration(notify_handle);
 				free(hotplug_cb);
-				register_global_error(L"Failed to allocate memory for a device info snapshot");
 				return -1;
 			}
 			replay_tail = &(*replay_tail)->next;
@@ -1641,14 +2060,16 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 
 	/* Have the snapshot delivered on the event context; never from within this call */
 	if (hotplug_cb->replay != NULL) {
-		SubmitThreadpoolWork(hid_hotplug_context.event_work);
+		hid_internal_SubmitThreadpoolWork(hid_hotplug_context.event_work);
 	}
 
-	LeaveCriticalSection(&hid_hotplug_context.critical_section);
-
 	/* A successful registration leaves no stale error behind (the internal
-	   enumeration of an empty system registers "No HID devices found") */
+	   enumeration of an empty system registers "No HID devices found").
+	   Under the critical section: outside of it this would race with - and wipe -
+	   the error string of a concurrently failing registration. */
 	register_global_error(NULL);
+
+	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
 	return 0;
 }
@@ -1658,13 +2079,21 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 	int result = -1;
 	HCMNOTIFICATION notify_handle;
 
-	if (callback_handle <= 0 || !hid_hotplug_context.mutex_ready) {
+	if (callback_handle <= 0 || !hid_internal_hotplug_ready()) {
 		register_global_error(L"Invalid or unknown hotplug callback handle");
 		return -1;
 	}
 
 	/* Lock the mutex to avoid race conditions */
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
+
+	if (hid_hotplug_context.exiting) {
+		/* hid_exit() deregisters every callback and invalidates every handle:
+		   this one is (or is about to be) one of them */
+		register_global_error(L"Invalid or unknown hotplug callback handle");
+		LeaveCriticalSection(&hid_hotplug_context.critical_section);
+		return -1;
+	}
 
 	/* Remove this notification */
 	for (struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs; *current != NULL; current = &(*current)->next) {
@@ -1693,15 +2122,17 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 		}
 	}
 
+	if (result != 0) {
+		/* Under the critical section: outside of it this would race with - and wipe -
+		   the error string of a concurrently failing hotplug call */
+		register_global_error(L"Invalid or unknown hotplug callback handle");
+	}
+
 	notify_handle = hid_internal_hotplug_cleanup();
 
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
 	hid_internal_hotplug_finish_unregistration(notify_handle);
-
-	if (result != 0) {
-		register_global_error(L"Invalid or unknown hotplug callback handle");
-	}
 
 	return result;
 }

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -475,9 +475,11 @@ static wchar_t *last_global_error_str = NULL;
    hands the raw string pointer out to the application without any lock, which
    is why the header requires the application to serialize hid_error(NULL)
    against the hotplug API. HIDAPI's own code on the internal event context
-   never writes the global error; a user callback that calls the public hotplug
-   API from the event context does, and that same serialization requirement in
-   the header covers it. */
+   never writes the global error - not even a user callback that re-enters the
+   public hotplug API from that context: register_global_error_message() drops
+   those writes (see the mutex_in_use guard there). An application therefore
+   never has to serialize hid_error(NULL) against a write it could not see
+   coming, matching the other backends (libusb, linux, mac). */
 static hid_internal_lock global_error_lock = 0;
 
 /* Publishes a message (built by the caller, ownership taken) as the global
@@ -486,6 +488,19 @@ static hid_internal_lock global_error_lock = 0;
 static void register_global_error_message(wchar_t *msg)
 {
 	wchar_t *old_msg;
+
+	/* A user callback runs on HIDAPI's internal event context (a threadpool
+	   work item or the CM notification callback), where mutex_in_use is set for
+	   the whole dispatch. A nested public hotplug call made from such a callback
+	   must not touch last_global_error_str - success clear included: the write
+	   happens on the event context, and the application cannot serialize its
+	   lock-free hid_error(NULL) read against it. Drop the write instead. This is
+	   a cheap byte read of a flag the dispatching thread itself set (and the same
+	   thread holds the critical section), so it adds no lock-order edge. */
+	if (hid_hotplug_context.mutex_in_use) {
+		free(msg);
+		return;
+	}
 
 	hid_internal_lock_acquire(&global_error_lock);
 	old_msg = last_global_error_str;
@@ -2947,6 +2962,11 @@ int HID_API_EXPORT_CALL hid_winapi_get_container_id(hid_device *dev, GUID *conta
 
 	if (!container_id) {
 		register_string_error(dev, L"Invalid Container ID");
+		return -1;
+	}
+
+	if (!dev->device_info) {
+		register_string_error(dev, L"NULL device info");
 		return -1;
 	}
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -469,6 +469,15 @@ static void hid_internal_lock_release(hid_internal_lock *lock)
 
 static wchar_t *last_global_error_str = NULL;
 
+/* Thread-local: true only while THIS thread is inside a user hotplug callback,
+   i.e. it is HIDAPI's internal event context. Thread-specific on purpose - the
+   event context is not a single fixed thread (a threadpool work item or the CM
+   notification callback), so a stored thread id would be fragile, and the flag
+   must be true for the dispatching thread alone, never for a concurrent
+   application thread. This is how mac/libusb detect the event context (they
+   compare its thread identity). */
+static __declspec(thread) int hid_in_hotplug_callback = 0;
+
 /* Serializes mutations of last_global_error_str: the hotplug API is
    thread-safe and its failure paths may write the global error concurrently.
    Note that this only protects writers against each other: hid_error(NULL)
@@ -477,9 +486,9 @@ static wchar_t *last_global_error_str = NULL;
    against the hotplug API. HIDAPI's own code on the internal event context
    never writes the global error - not even a user callback that re-enters the
    public hotplug API from that context: register_global_error_message() drops
-   those writes (see the mutex_in_use guard there). An application therefore
-   never has to serialize hid_error(NULL) against a write it could not see
-   coming, matching the other backends (libusb, linux, mac). */
+   those writes (see hid_in_hotplug_callback). An application therefore never
+   has to serialize hid_error(NULL) against a write it could not see coming,
+   matching the other backends (libusb, linux, mac). */
 static hid_internal_lock global_error_lock = 0;
 
 /* Publishes a message (built by the caller, ownership taken) as the global
@@ -490,14 +499,15 @@ static void register_global_error_message(wchar_t *msg)
 	wchar_t *old_msg;
 
 	/* A user callback runs on HIDAPI's internal event context (a threadpool
-	   work item or the CM notification callback), where mutex_in_use is set for
-	   the whole dispatch. A nested public hotplug call made from such a callback
-	   must not touch last_global_error_str - success clear included: the write
-	   happens on the event context, and the application cannot serialize its
-	   lock-free hid_error(NULL) read against it. Drop the write instead. This is
-	   a cheap byte read of a flag the dispatching thread itself set (and the same
-	   thread holds the critical section), so it adds no lock-order edge. */
-	if (hid_hotplug_context.mutex_in_use) {
+	   work item or the CM notification callback). A nested public hotplug call
+	   made from such a callback must not touch last_global_error_str - success
+	   clear included: the write happens on the event context, and the
+	   application cannot serialize its lock-free hid_error(NULL) read against it.
+	   hid_in_hotplug_callback is thread-local and set only around the callback
+	   invocation, so this drops writes on the dispatching thread alone. A
+	   concurrent application thread (its own flag is 0) still records its errors,
+	   and reading a thread-local is not a shared-memory data race. */
+	if (hid_in_hotplug_callback) {
 		free(msg);
 		return;
 	}
@@ -1067,7 +1077,13 @@ static void hid_internal_hotplug_replay_flush(struct hid_hotplug_callback *callb
 			continue;
 		}
 
+		/* Mark this thread as the event context for the duration of the call, so a
+		   nested public hotplug call does not write the global error (save/restore
+		   keeps nested callbacks composing correctly). */
+		int prev_in_cb = hid_in_hotplug_callback;
+		hid_in_hotplug_callback = 1;
 		int result = (*callback->callback)(callback->handle, device, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED, callback->user_data);
+		hid_in_hotplug_callback = prev_in_cb;
 		hid_free_enumeration(device);
 
 		/* A non-zero result stops the remainder of the pass and deregisters the callback */
@@ -1933,7 +1949,12 @@ static void hid_internal_hotplug_dispatch(struct hid_device_info *device, hid_ho
 		hid_internal_hotplug_replay_flush(callback);
 
 		if ((callback->events & hotplug_event) && hid_internal_match_device_id(device->vendor_id, device->product_id, callback->vendor_id, callback->product_id)) {
+			/* Mark this thread as the event context for the duration of the call
+			   (see hid_in_hotplug_callback); save/restore for nested callbacks. */
+			int prev_in_cb = hid_in_hotplug_callback;
+			hid_in_hotplug_callback = 1;
 			int result = (callback->callback)(callback->handle, device, hotplug_event, callback->user_data);
+			hid_in_hotplug_callback = prev_in_cb;
 
 			/* If the result is non-zero, we MARK the callback for future removal and proceed */
 			/* We avoid changing the list until we are done calling the callbacks to simplify the process */

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -30,6 +30,14 @@ extern "C" {
 #undef WIN32_LEAN_AND_MEAN
 #endif
 
+/* The native threadpool API (CreateThreadpoolWork & co), used to deliver
+ * the HID_API_HOTPLUG_ENUMERATE pass asynchronously, is only declared
+ * for Windows Vista and up. */
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0600)
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
 #include "hidapi_winapi.h"
 
 #include <windows.h>
@@ -48,6 +56,7 @@ typedef LONG NTSTATUS;
 #include <ntdef.h>
 #include <wctype.h>
 #define _wcsdup wcsdup
+#define _strdup strdup
 #define _stricmp strcasecmp
 #endif
 
@@ -219,6 +228,11 @@ struct hid_device_ {
 static struct hid_hotplug_context {
 	/* Win32 notification handle */
 	HCMNOTIFICATION notify_handle;
+
+	/* Threadpool work item: delivers pending HID_API_HOTPLUG_ENUMERATE
+	   passes and performs cleanup deferred from the notification callback.
+	   Created with the first callback registration, closed by hid_exit(). */
+	PTP_WORK event_work;
 
 	/* Critical section (faster mutex substitute), for both cached device list and callback list changes */
 	CRITICAL_SECTION critical_section;
@@ -451,9 +465,40 @@ struct hid_hotplug_callback {
     void *user_data;
     hid_hotplug_callback_fn callback;
 
+    /* HID_API_HOTPLUG_ENUMERATE snapshot taken at registration time,
+       still to be replayed to this callback as synthetic
+       HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED events on the event context */
+    struct hid_device_info *replay;
+
     /* Pointer to the next notification */
     struct hid_hotplug_callback *next;
 };
+
+static struct hid_device_info *hid_internal_copy_device_info(const struct hid_device_info *src)
+{
+	struct hid_device_info *dst = (struct hid_device_info *)calloc(1, sizeof(struct hid_device_info));
+
+	if (dst == NULL) {
+		return NULL;
+	}
+
+	*dst = *src;
+	dst->next = NULL;
+	dst->path = NULL;
+	dst->serial_number = NULL;
+	dst->manufacturer_string = NULL;
+	dst->product_string = NULL;
+
+	if ((src->path && (dst->path = _strdup(src->path)) == NULL)
+	    || (src->serial_number && (dst->serial_number = _wcsdup(src->serial_number)) == NULL)
+	    || (src->manufacturer_string && (dst->manufacturer_string = _wcsdup(src->manufacturer_string)) == NULL)
+	    || (src->product_string && (dst->product_string = _wcsdup(src->product_string)) == NULL)) {
+		hid_free_enumeration(dst);
+		return NULL;
+	}
+
+	return dst;
+}
 
 static void hid_internal_hotplug_remove_postponed()
 {
@@ -470,29 +515,49 @@ static void hid_internal_hotplug_remove_postponed()
 		struct hid_hotplug_callback *callback = *current;
 		if (!callback->events) {
 			*current = (*current)->next;
+			hid_free_enumeration(callback->replay);
 			free(callback);
 			continue;
 		}
 		current = &callback->next;
 	}
-	
+
 	/* Clear the flag so we don't start the cycle unless necessary */
 	hid_hotplug_context.cb_list_dirty = 0;
 }
 
-static void hid_internal_hotplug_cleanup()
+static void hid_internal_hotplug_unregister_notification(HCMNOTIFICATION notify_handle)
 {
-	if (!hid_hotplug_context.mutex_ready || hid_hotplug_context.mutex_in_use) {
+	if (notify_handle == NULL) {
 		return;
+	}
+
+	if (CM_Unregister_Notification(notify_handle) != CR_SUCCESS) {
+		register_global_error(L"CM_Unregister_Notification failed for Hotplug notification");
+	}
+}
+
+/* Always called inside a locked mutex.
+   When the last callback is gone, tears the machinery down and returns the
+   Win32 notification handle: CM_Unregister_Notification waits for in-progress
+   notification callbacks, which in turn may be blocked on our critical
+   section, so the caller must invoke it only after leaving the critical
+   section (and never from the notification callback itself: the notification
+   callback defers the teardown to the threadpool work item instead). */
+static HCMNOTIFICATION hid_internal_hotplug_cleanup()
+{
+	HCMNOTIFICATION notify_handle;
+
+	if (!hid_hotplug_context.mutex_ready || hid_hotplug_context.mutex_in_use) {
+		return NULL;
 	}
 
 	/* Before checking if the list is empty, clear any entries whose removal was postponed first */
 	hid_internal_hotplug_remove_postponed();
 
 	/* Unregister the HID device connection notification when removing the last callback */
-	/* This function is always called inside a locked mutex */
 	if (hid_hotplug_context.hotplug_cbs != NULL) {
-		return;
+		return NULL;
 	}
 
 	if (hid_hotplug_context.devs) {
@@ -501,32 +566,102 @@ static void hid_internal_hotplug_cleanup()
 		hid_hotplug_context.devs = NULL;
 	}
 
-	if (hid_hotplug_context.notify_handle) {
-		if (CM_Unregister_Notification(hid_hotplug_context.notify_handle) != CR_SUCCESS) {
-			/* We mark an error, but we proceed with the cleanup */
-			register_global_error(L"CM_Unregister_Notification failed for Hotplug notification");
+	notify_handle = hid_hotplug_context.notify_handle;
+	hid_hotplug_context.notify_handle = NULL;
+	return notify_handle;
+}
+
+/* Deliver (and consume) a callback's pending HID_API_HOTPLUG_ENUMERATE
+   snapshot. Always called inside a locked mutex, with mutex_in_use set. */
+static void hid_internal_hotplug_replay_flush(struct hid_hotplug_callback *callback)
+{
+	while (callback->replay != NULL) {
+		struct hid_device_info *device = callback->replay;
+		callback->replay = device->next;
+		device->next = NULL;
+
+		if (!callback->events) {
+			/* The callback was deregistered while the pass was pending */
+			hid_free_enumeration(device);
+			continue;
+		}
+
+		int result = (*callback->callback)(callback->handle, device, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED, callback->user_data);
+		hid_free_enumeration(device);
+
+		/* A non-zero result stops the remainder of the pass and deregisters the callback */
+		if (result) {
+			callback->events = 0;
+			hid_hotplug_context.cb_list_dirty = 1;
+			hid_free_enumeration(callback->replay);
+			callback->replay = NULL;
 		}
 	}
+}
 
-	hid_hotplug_context.notify_handle = NULL;
+/* Threadpool work item: delivers pending HID_API_HOTPLUG_ENUMERATE passes
+   (unless a live event got to them first) and performs the cleanup the
+   notification callback is not allowed to perform itself. */
+static VOID CALLBACK hid_internal_hotplug_event_work(PTP_CALLBACK_INSTANCE instance, PVOID context, PTP_WORK work)
+{
+	HCMNOTIFICATION notify_handle;
+
+	(void)instance;
+	(void)context;
+	(void)work;
+
+	EnterCriticalSection(&hid_hotplug_context.critical_section);
+
+	hid_hotplug_context.mutex_in_use = 1;
+	for (struct hid_hotplug_callback *callback = hid_hotplug_context.hotplug_cbs; callback != NULL; callback = callback->next) {
+		hid_internal_hotplug_replay_flush(callback);
+	}
+	hid_hotplug_context.mutex_in_use = 0;
+
+	notify_handle = hid_internal_hotplug_cleanup();
+
+	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+	hid_internal_hotplug_unregister_notification(notify_handle);
 }
 
 static void hid_internal_hotplug_exit()
 {
+	HCMNOTIFICATION notify_handle;
+
 	if (!hid_hotplug_context.mutex_ready) {
 		/* If the critical section is not initialized, we are safe to assume nothing else is */
 		return;
 	}
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 	struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
-	/* Remove all callbacks from the list */
+	/* Remove all callbacks from the list, including their undelivered HID_API_HOTPLUG_ENUMERATE snapshots */
 	while (*current) {
 		struct hid_hotplug_callback *next = (*current)->next;
+		hid_free_enumeration((*current)->replay);
 		free(*current);
 		*current = next;
 	}
-	hid_internal_hotplug_cleanup();
+	notify_handle = hid_internal_hotplug_cleanup();
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+	hid_internal_hotplug_unregister_notification(notify_handle);
+
+	if (hid_hotplug_context.event_work) {
+		/* Wait for any in-flight work item before the critical section goes away.
+		   hid_exit() must not be called from a callback, so this cannot deadlock. */
+		WaitForThreadpoolWorkCallbacks(hid_hotplug_context.event_work, FALSE);
+		CloseThreadpoolWork(hid_hotplug_context.event_work);
+		hid_hotplug_context.event_work = NULL;
+	}
+
+	/* A last-gasp notification callback may have re-added a device between
+	   the cleanup and the unregistration; nothing can race us anymore here */
+	if (hid_hotplug_context.devs != NULL) {
+		hid_free_enumeration(hid_hotplug_context.devs);
+		hid_hotplug_context.devs = NULL;
+	}
+
 	hid_hotplug_context.mutex_ready = 0;
 	DeleteCriticalSection(&hid_hotplug_context.critical_section);
 }
@@ -1151,14 +1286,25 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 	if (device) {
 		/* Mark the critical section as IN USE, to prevent callback removal from inside a callback */
 		hid_hotplug_context.mutex_in_use = 1;
-		
+
+		/* Callbacks registered from inside a callback are appended to the list
+		   and see this device in their registration-time HID_API_HOTPLUG_ENUMERATE
+		   snapshot (or don't, for a removal): the live dispatch is bound to the
+		   callbacks present at event time, so the connection is reported exactly once */
+		struct hid_hotplug_callback *last_at_event = hid_hotplug_context.hotplug_cbs;
+		while (last_at_event != NULL && last_at_event->next != NULL) {
+			last_at_event = last_at_event->next;
+		}
+
 		/* Call the notifications for the device */
-		struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
-		while (*current) {
-			struct hid_hotplug_callback *callback = *current;
+		for (struct hid_hotplug_callback *callback = hid_hotplug_context.hotplug_cbs; callback != NULL; callback = callback->next) {
+			/* The registration-time enumeration pass is always delivered
+			   before any live events for the callback */
+			hid_internal_hotplug_replay_flush(callback);
+
 			if ((callback->events & hotplug_event) && hid_internal_match_device_id(device->vendor_id, device->product_id, callback->vendor_id, callback->product_id)) {
 				int result = (callback->callback)(callback->handle, device, hotplug_event, callback->user_data);
-				
+
 				/* If the result is non-zero, we MARK the callback for future removal and proceed */
 				/* We avoid changing the list until we are done calling the callbacks to simplify the process */
 				if (result) {
@@ -1166,7 +1312,10 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 					hid_hotplug_context.cb_list_dirty = 1;
 				}
 			}
-			current = &callback->next;
+
+			if (callback == last_at_event) {
+				break;
+			}
 		}
 
 		hid_hotplug_context.mutex_in_use = 0;
@@ -1176,8 +1325,13 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 			hid_free_enumeration(device);
 		}
 
-		/* Remove any callbacks that were marked for removal and stop the notification if none are left */
-		hid_internal_hotplug_cleanup();
+		/* Remove any callbacks that were marked for removal; if none are left,
+		   defer the teardown to the threadpool work item: unregistering the
+		   notification from its own callback is not allowed (deadlock) */
+		hid_internal_hotplug_remove_postponed();
+		if (hid_hotplug_context.hotplug_cbs == NULL && hid_hotplug_context.event_work != NULL) {
+			SubmitThreadpoolWork(hid_hotplug_context.event_work);
+		}
 	}
 
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
@@ -1189,17 +1343,30 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 {
 	struct hid_hotplug_callback* hotplug_cb;
 
+	/* No events can be delivered before the handle is written */
+	if (callback_handle != NULL) {
+		*callback_handle = 0;
+	}
+
 	/* Check params */
+	if (callback == NULL) {
+		register_global_error(L"Callback function is NULL");
+		return -1;
+	}
 	if (events == 0
-		|| (events & ~(HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT))
-		|| (flags & ~(HID_API_HOTPLUG_ENUMERATE))
-		|| callback == NULL) {
+		|| (events & ~(HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT))) {
+		register_global_error(L"Invalid events mask");
+		return -1;
+	}
+	if (flags & ~(HID_API_HOTPLUG_ENUMERATE)) {
+		register_global_error(L"Invalid flags");
 		return -1;
 	}
 
 	hotplug_cb = (struct hid_hotplug_callback*)calloc(1, sizeof(struct hid_hotplug_callback));
 
 	if (hotplug_cb == NULL) {
+		register_global_error(L"Failed to allocate memory for a hotplug callback");
 		return -1;
 	}
 
@@ -1210,6 +1377,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	hotplug_cb->events = events;
 	hotplug_cb->user_data = user_data;
 	hotplug_cb->callback = callback;
+	hotplug_cb->replay = NULL;
 
 	/* Ensure we are ready to actually use the mutex */
 	hid_internal_hotplug_init();
@@ -1225,12 +1393,88 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 		hid_hotplug_context.next_handle = 1;
 	}
 
-	/* Return allocated handle */
-	if (callback_handle != NULL) {
-		*callback_handle = hotplug_cb->handle;
+	/* Start the machinery with the first callback */
+	if (hid_hotplug_context.hotplug_cbs == NULL) {
+		if (hid_init() < 0) {
+			/* register_global_error: global error is already set by hid_init */
+			LeaveCriticalSection(&hid_hotplug_context.critical_section);
+			free(hotplug_cb);
+			return -1;
+		}
+
+		if (hid_hotplug_context.event_work == NULL) {
+			hid_hotplug_context.event_work = CreateThreadpoolWork(hid_internal_hotplug_event_work, NULL, NULL);
+			if (hid_hotplug_context.event_work == NULL) {
+				LeaveCriticalSection(&hid_hotplug_context.critical_section);
+				free(hotplug_cb);
+				register_global_error(L"hid_hotplug_register_callback/CreateThreadpoolWork");
+				return -1;
+			}
+		}
+
+		/* Refresh the device cache: a teardown deferred to the work item may not have run yet */
+		if (hid_hotplug_context.devs != NULL) {
+			hid_free_enumeration(hid_hotplug_context.devs);
+			hid_hotplug_context.devs = NULL;
+		}
+
+		/* Fill already connected devices so we can use this info in disconnection
+		   notifications and HID_API_HOTPLUG_ENUMERATE passes (hid_enumerate also
+		   implicitly initializes the library, as if by hid_init) */
+		hid_hotplug_context.devs = hid_enumerate(0, 0);
+
+		if (hid_hotplug_context.notify_handle == NULL) {
+			GUID interface_class_guid;
+			CM_NOTIFY_FILTER notify_filter = { 0 };
+
+			/* Retrieve HID Interface Class GUID
+				https://docs.microsoft.com/windows-hardware/drivers/install/guid-devinterface-hid */
+			HidD_GetHidGuid(&interface_class_guid);
+
+			notify_filter.cbSize = sizeof(notify_filter);
+			notify_filter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
+			notify_filter.u.DeviceInterface.ClassGuid = interface_class_guid;
+
+			/* Register for a HID device notification when adding the first callback */
+			if (CM_Register_Notification(&notify_filter, NULL, hid_internal_notify_callback, &hid_hotplug_context.notify_handle) != CR_SUCCESS) {
+				hid_hotplug_context.notify_handle = NULL;
+				if (hid_hotplug_context.devs != NULL) {
+					hid_free_enumeration(hid_hotplug_context.devs);
+					hid_hotplug_context.devs = NULL;
+				}
+				LeaveCriticalSection(&hid_hotplug_context.critical_section);
+				free(hotplug_cb);
+				register_global_error(L"hid_hotplug_register_callback/CM_Register_Notification");
+				return -1;
+			}
+		}
 	}
 
-	/* Append a new callback to the end */
+	/* Take the registration-time snapshot to be replayed asynchronously
+	   on the event context, one exact copy per matching connected device */
+	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
+		struct hid_device_info **replay_tail = &hotplug_cb->replay;
+		for (struct hid_device_info *device = hid_hotplug_context.devs; device != NULL; device = device->next) {
+			if (!hid_internal_match_device_id(device->vendor_id, device->product_id, vendor_id, product_id)) {
+				continue;
+			}
+			*replay_tail = hid_internal_copy_device_info(device);
+			if (*replay_tail == NULL) {
+				HCMNOTIFICATION notify_handle;
+				hid_free_enumeration(hotplug_cb->replay);
+				/* Tear the machinery down if this would-be-first callback was starting it */
+				notify_handle = hid_internal_hotplug_cleanup();
+				LeaveCriticalSection(&hid_hotplug_context.critical_section);
+				hid_internal_hotplug_unregister_notification(notify_handle);
+				free(hotplug_cb);
+				register_global_error(L"Failed to allocate memory for a device info snapshot");
+				return -1;
+			}
+			replay_tail = &(*replay_tail)->next;
+		}
+	}
+
+	/* Append the new callback to the end of the list */
 	if (hid_hotplug_context.hotplug_cbs != NULL) {
 		struct hid_hotplug_callback *last = hid_hotplug_context.hotplug_cbs;
 		while (last->next != NULL) {
@@ -1239,57 +1483,19 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 		last->next = hotplug_cb;
 	}
 	else {
-		GUID interface_class_guid;
-		CM_NOTIFY_FILTER notify_filter = { 0 };
-
-		/* Fill already connected devices so we can use this info in disconnection notification */
-		hid_hotplug_context.devs = hid_enumerate(0, 0);
-
 		hid_hotplug_context.hotplug_cbs = hotplug_cb;
-
-		if (hid_hotplug_context.notify_handle != NULL) {
-			register_global_error(L"Device notification have already been registered");
-			LeaveCriticalSection(&hid_hotplug_context.critical_section);
-			return -1;
-		}
-
-		/* Retrieve HID Interface Class GUID
-			https://docs.microsoft.com/windows-hardware/drivers/install/guid-devinterface-hid */
-		HidD_GetHidGuid(&interface_class_guid);
-
-		notify_filter.cbSize = sizeof(notify_filter);
-		notify_filter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
-		notify_filter.u.DeviceInterface.ClassGuid = interface_class_guid;
-
-		/* Register for a HID device notification when adding the first callback */
-		if (CM_Register_Notification(&notify_filter, NULL, hid_internal_notify_callback, &hid_hotplug_context.notify_handle) != CR_SUCCESS) {
-			register_global_error(L"hid_hotplug_register_callback/CM_Register_Notification");
-			LeaveCriticalSection(&hid_hotplug_context.critical_section);
-			return -1;
-		}
 	}
 
-	/* Mark the critical section as IN USE, to prevent callback removal from inside a callback */
-	unsigned char old_state = hid_hotplug_context.mutex_in_use;
-	hid_hotplug_context.mutex_in_use = 1;
-	
-	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
-		struct hid_device_info* device = hid_hotplug_context.devs;
-		/* Notify about already connected devices, if asked so */
-		while (device != NULL) {
-			if (hid_internal_match_device_id(device->vendor_id, device->product_id, hotplug_cb->vendor_id, hotplug_cb->product_id)) {
-				(*hotplug_cb->callback)(hotplug_cb->handle, device, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED, hotplug_cb->user_data);
-			}
-
-			device = device->next;
-		}
+	/* Return allocated handle */
+	if (callback_handle != NULL) {
+		*callback_handle = hotplug_cb->handle;
 	}
 
-	hid_hotplug_context.mutex_in_use = old_state;
+	/* Have the snapshot delivered on the event context; never from within this call */
+	if (hotplug_cb->replay != NULL) {
+		SubmitThreadpoolWork(hid_hotplug_context.event_work);
+	}
 
-	/* Remove any callbacks that were marked for removal and stop the notification if none are left */
-	hid_internal_hotplug_cleanup();
-	
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
 	return 0;
@@ -1297,21 +1503,29 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 
 int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_callback_handle callback_handle)
 {
+	int result = -1;
+	HCMNOTIFICATION notify_handle;
+
 	if (callback_handle <= 0 || !hid_hotplug_context.mutex_ready) {
+		register_global_error(L"Invalid or unknown hotplug callback handle");
 		return -1;
 	}
 
 	/* Lock the mutex to avoid race conditions */
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
-	if (!hid_hotplug_context.hotplug_cbs) {
-		LeaveCriticalSection(&hid_hotplug_context.critical_section);
-		return -1;
-	}
-
 	/* Remove this notification */
 	for (struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs; *current != NULL; current = &(*current)->next) {
 		if ((*current)->handle == callback_handle) {
+			/* A callback already marked for removal counts as deregistered */
+			if (!(*current)->events) {
+				break;
+			}
+
+			/* Undelivered HID_API_HOTPLUG_ENUMERATE events must never fire after deregistration */
+			hid_free_enumeration((*current)->replay);
+			(*current)->replay = NULL;
+
 			/* Check if we were already in the critical section, as we are NOT allowed to remove any callbacks if we are */
 			if (hid_hotplug_context.mutex_in_use) {
 				/* If we are not allowed to remove the callback, we mark it as pending removal */
@@ -1322,15 +1536,22 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 				free(*current);
 				*current = next;
 			}
+			result = 0;
 			break;
 		}
 	}
 
-	hid_internal_hotplug_cleanup();
+	notify_handle = hid_internal_hotplug_cleanup();
 
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
-	return 0;
+	hid_internal_hotplug_unregister_notification(notify_handle);
+
+	if (result != 0) {
+		register_global_error(L"Invalid or unknown hotplug callback handle");
+	}
+
+	return result;
 }
 
 HID_API_EXPORT hid_device * HID_API_CALL hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -239,21 +239,6 @@ static SubmitThreadpoolWork_ hid_internal_SubmitThreadpoolWork = NULL;
 static CloseThreadpoolWork_ hid_internal_CloseThreadpoolWork = NULL;
 static WaitForThreadpoolWorkCallbacks_ hid_internal_WaitForThreadpoolWorkCallbacks = NULL;
 
-/* An interface path captured by the registration-time enumeration whose arrival
-   notification may still be in flight. See hid_internal_hotplug_record_pending_arrivals. */
-struct hid_hotplug_path {
-	char *path;
-	struct hid_hotplug_path *next;
-};
-
-/* How long (in milliseconds) the pending-arrivals list stays authoritative.
-   The duplicate arrival it suppresses was already queued by the OS when the
-   list was recorded and is delivered about as soon as the registration releases
-   the critical section, so anything this old is not that duplicate - it is a
-   genuine re-arrival on a path whose removal notification was missed (see
-   hid_internal_hotplug_take_pending_arrival). */
-#define HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS 10000
-
 static struct hid_hotplug_context {
 	/* Win32 notification handle */
 	HCMNOTIFICATION notify_handle;
@@ -298,15 +283,10 @@ static struct hid_hotplug_context {
 	/* Linked list of the hotplug callbacks */
 	struct hid_hotplug_callback *hotplug_cbs;
 
-	/* Linked list of the device infos (mandatory when the device is disconnected) */
+	/* Linked list of the device infos (mandatory when the device is disconnected).
+	   Doubles as the arrival dedupe set: an arrival for a path that is already in
+	   here has already been reported (see hid_internal_notify_callback). */
 	struct hid_device_info *devs;
-
-	/* Paths whose arrival notification may still be in flight while it has
-	   already been reported by the registration-time enumeration, and the
-	   GetTickCount() timestamp of the moment they were recorded (see
-	   HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS) */
-	struct hid_hotplug_path *pending_arrivals;
-	DWORD pending_arrivals_tick;
 } hid_hotplug_context; /* zero-initialized (static storage); next_handle set on first init */
 
 static hid_device *new_hid_device()
@@ -809,88 +789,26 @@ static void hid_internal_hotplug_pin_module(void)
 		(LPCWSTR)(void *)&hid_hotplug_context, &module);
 }
 
-/* Always called inside a locked mutex */
-static void hid_internal_hotplug_free_pending_arrivals(void)
+/* Tells whether an interface path is already in the device cache - i.e. whether
+   its connection has already been reported. Always called inside a locked mutex.
+
+   This is the whole arrival dedupe. The notification is armed BEFORE the
+   registration-time enumeration runs (a device connecting in between must not be
+   missed by both), so a device that arrives in that window is captured by the
+   enumeration AND has an arrival notification in flight; that notification must
+   not report - or cache - the same connection a second time.
+
+   The cache decides it, with no timing assumption anywhere: the OS delivers
+   exactly one arrival notification per interface instance, so that overlap is the
+   only way an arrival can be a duplicate - and in that case the enumeration has,
+   by construction, already put the device in the cache. Conversely the removal
+   notification is authoritative and drops the cache entry, so a genuine re-plug
+   (even onto the same, reused path) is NOT cached and IS reported. */
+static int hid_internal_hotplug_is_cached(const char *path)
 {
-	struct hid_hotplug_path *current = hid_hotplug_context.pending_arrivals;
-
-	hid_hotplug_context.pending_arrivals = NULL;
-
-	while (current != NULL) {
-		struct hid_hotplug_path *next = current->next;
-		free(current->path);
-		free(current);
-		current = next;
-	}
-}
-
-/* Records the interface paths the registration-time enumeration has just captured.
-   Always called inside a locked mutex; returns -1 on allocation failure.
-
-   The notification is armed BEFORE the enumeration runs (a device connecting in
-   between must not be missed by both), so a device that arrives in that window is
-   picked up by the enumeration AND has an arrival notification in flight. That
-   notification must not report - or cache - the same connection a second time.
-
-   This window is the only place where a duplicate arrival can occur, so the
-   suppression is scoped to it: a recorded path swallows at most one arrival and is
-   dropped as soon as the device leaves. Outside of it, an arrival for a path that
-   is still cached is NOT a duplicate: an interface path is reused when a device is
-   replugged into the same port, so suppressing it would swallow a real connection. */
-static int hid_internal_hotplug_record_pending_arrivals(void)
-{
-	hid_hotplug_context.pending_arrivals_tick = GetTickCount();
-
 	for (struct hid_device_info *device = hid_hotplug_context.devs; device != NULL; device = device->next) {
-		struct hid_hotplug_path *entry = (struct hid_hotplug_path *)calloc(1, sizeof(struct hid_hotplug_path));
-
-		if (entry == NULL) {
-			return -1;
-		}
-
-		/* Cached devices always have a path (hid_internal_get_device_info fails without one) */
-		entry->path = _strdup(device->path);
-		if (entry->path == NULL) {
-			free(entry);
-			return -1;
-		}
-
-		entry->next = hid_hotplug_context.pending_arrivals;
-		hid_hotplug_context.pending_arrivals = entry;
-	}
-
-	return 0;
-}
-
-/* Consumes the pending-arrival record for this path, if there is one.
-   Always called inside a locked mutex.
-   Returns 1 when this arrival was already reported by the registration-time
-   enumeration (see hid_internal_hotplug_record_pending_arrivals) and must be
-   dropped, 0 when it is a genuine new connection. */
-static int hid_internal_hotplug_take_pending_arrival(const char *path)
-{
-	/* An expired list suppresses nothing: the duplicate it exists for would have
-	   long been delivered (see HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS). Devices
-	   whose records outlive the window are devices whose removal notification
-	   was missed - consuming the record on their eventual re-arrival would
-	   swallow a genuine connection and keep the stale-record recovery in
-	   hid_internal_notify_callback from ever running. Between the two failure
-	   modes the expiry errs towards the recoverable one: a duplicate that
-	   somehow outlives the window is reported as a spurious LEFT+ARRIVED pair
-	   instead of a connection being silently dropped. */
-	if (hid_hotplug_context.pending_arrivals != NULL
-	    && GetTickCount() - hid_hotplug_context.pending_arrivals_tick > HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS) {
-		hid_internal_hotplug_free_pending_arrivals();
-		return 0;
-	}
-
-	for (struct hid_hotplug_path **current = &hid_hotplug_context.pending_arrivals; *current != NULL; current = &(*current)->next) {
 		/* Case-independent path comparison is mandatory */
-		if (_stricmp((*current)->path, path) == 0) {
-			struct hid_hotplug_path *entry = *current;
-			*current = entry->next;
-			free(entry->path);
-			free(entry);
+		if (device->path != NULL && _stricmp(device->path, path) == 0) {
 			return 1;
 		}
 	}
@@ -1026,8 +944,6 @@ static HCMNOTIFICATION hid_internal_hotplug_cleanup()
 		hid_free_enumeration(hid_hotplug_context.devs);
 		hid_hotplug_context.devs = NULL;
 	}
-
-	hid_internal_hotplug_free_pending_arrivals();
 
 	notify_handle = hid_hotplug_context.notify_handle;
 	hid_hotplug_context.notify_handle = NULL;
@@ -1215,7 +1131,6 @@ static int hid_internal_hotplug_exit(void)
 	   cleanup and the completion of the unregistration */
 	hid_free_enumeration(hid_hotplug_context.devs);
 	hid_hotplug_context.devs = NULL;
-	hid_internal_hotplug_free_pending_arrivals();
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
 	if (!keep_machinery) {
@@ -1963,9 +1878,13 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 		if (path == NULL) {
 			/* Out of memory: there is nothing to report the connection with, and
 			   nothing is cached, so the cache stays consistent */
-		} else if (hid_internal_hotplug_take_pending_arrival(path)) {
-			/* Already reported (and cached) by the registration-time enumeration:
-			   see hid_internal_hotplug_record_pending_arrivals */
+		} else if (hid_internal_hotplug_is_cached(path)) {
+			/* This connection is already known - and therefore already reported.
+			   The only way that happens is the arm-before-enumerate window at
+			   registration, where the enumeration cached the device and the OS had
+			   already queued this arrival for it (see
+			   hid_internal_hotplug_is_cached). Drop it whole: no second cache
+			   entry, no second dispatch. */
 		} else {
 			/* Open read-only handle to the device */
 			HANDLE read_handle = open_device(event_data->u.DeviceInterface.SymbolicLink, FALSE);
@@ -1977,25 +1896,6 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 			}
 
 			if (device != NULL) {
-				/* An interface path is reused when a device is replugged into the
-				   same port, so an arrival for a path that is still cached means the
-				   removal of the previous connection was missed. The previous
-				   connection is owed a DEVICE_LEFT (the header promises one for every
-				   matching device that disconnects while a callback is registered):
-				   deliver it synthetically from the stale record, then drop that
-				   record - a second record for the same path would never be removed -
-				   and report the new connection as the arrival it is. */
-				struct hid_device_info *stale_device = hid_internal_hotplug_take_cached_device(device->path);
-				if (stale_device != NULL) {
-					/* Dispatched before the new device is cached: a callback
-					   registered from inside one of these callbacks takes its
-					   HID_API_HOTPLUG_ENUMERATE snapshot from the cache, and must
-					   not see the new connection there AND as the live arrival
-					   dispatched below. */
-					hid_internal_hotplug_dispatch(stale_device, HID_API_HOTPLUG_EVENT_DEVICE_LEFT);
-					hid_free_enumeration(stale_device);
-				}
-
 				/* Append to the end of the device list */
 				if (hid_hotplug_context.devs != NULL) {
 					struct hid_device_info *last = hid_hotplug_context.devs;
@@ -2025,11 +1925,10 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 		path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink, NULL);
 
 		if (path != NULL) {
-			/* The device is gone: a later arrival on the same path is a new
-			   connection and must not be mistaken for a pending duplicate */
-			hid_internal_hotplug_take_pending_arrival(path);
-
-			/* Get and remove this device from the device list */
+			/* Get and remove this device from the device list. Dropping the entry is
+			   what makes a later arrival on the same path (an interface path is
+			   reused when a device is replugged into the same port) a new connection
+			   rather than a duplicate - see hid_internal_hotplug_is_cached. */
 			device = hid_internal_hotplug_take_cached_device(path);
 
 			free(path);
@@ -2168,8 +2067,8 @@ static int hid_internal_hotplug_register_counted(struct hid_hotplug_callback *ho
 			/* Register for a HID device notification when adding the first callback.
 			   Armed BEFORE the device cache is filled: a device connecting in between
 			   is then caught by the notification instead of being missed by both, and
-			   the duplicate that this creates is suppressed exactly once
-			   (see hid_internal_hotplug_record_pending_arrivals). */
+			   the duplicate that this creates is suppressed by the cache itself
+			   (see hid_internal_hotplug_is_cached). */
 			if (CM_Register_Notification(&notify_filter, NULL, hid_internal_notify_callback, &hid_hotplug_context.notify_handle) != CR_SUCCESS) {
 				register_global_error(L"hid_hotplug_register_callback/CM_Register_Notification");
 				hid_hotplug_context.notify_handle = NULL;
@@ -2182,15 +2081,10 @@ static int hid_internal_hotplug_register_counted(struct hid_hotplug_callback *ho
 			   between its detachment and the completion of its unregistration */
 			hid_free_enumeration(hid_hotplug_context.devs);
 			hid_hotplug_context.devs = NULL;
-			hid_internal_hotplug_free_pending_arrivals();
 
 			/* Fill already connected devices so we can use this info in disconnection
 			   notifications and HID_API_HOTPLUG_ENUMERATE passes */
 			hid_hotplug_context.devs = hid_internal_enumerate(0, 0, &enumerate_failure);
-			if (!enumerate_failure && hid_internal_hotplug_record_pending_arrivals() < 0) {
-				register_global_error(L"Failed to allocate memory for the hotplug device cache");
-				enumerate_failure = 1;
-			}
 			if (enumerate_failure) {
 				/* An empty system is fine; a failed enumeration is not: the device
 				   cache and the ENUMERATE snapshot would misrepresent the system.

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -49,7 +49,6 @@ typedef LONG NTSTATUS;
 #include <wctype.h>
 #define _wcsdup wcsdup
 #define _strdup strdup
-#define _stricmp strcasecmp
 #endif
 
 /*#define HIDAPI_USE_DDK*/
@@ -789,6 +788,88 @@ static void hid_internal_hotplug_pin_module(void)
 		(LPCWSTR)(void *)&hid_hotplug_context, &module);
 }
 
+/* ASCII case folding: locale-independent, and all an interface path needs
+   (this is also all the _stricmp() below used to do, in the C locale) */
+static unsigned char hid_internal_ascii_tolower(unsigned char c)
+{
+	return (c >= 'A' && c <= 'Z') ? (unsigned char)(c - 'A' + 'a') : c;
+}
+
+/* Compares a cached (UTF-8) interface path with the (UTF-16) one a notification
+   carries, WITHOUT ALLOCATING: it encodes the UTF-16 path to UTF-8 on the fly, one
+   code point at a time, and matches it against the bytes of the cached one.
+
+   Both hotplug cache lookups need this comparison, and both used to convert the
+   notification's symbolic link to UTF-8 first - which allocates. That allocation
+   failing in the REMOVAL lookup would process the removal but leave its cache
+   record behind, and a stale record is unrecoverable: it is the arrival dedupe, so
+   the next connection on that interface path (paths are reused when a device is
+   replugged into the same port) would be classified as a duplicate and suppressed
+   forever, for every callback, including later HID_API_HOTPLUG_ENUMERATE passes.
+   With no allocation on either lookup, an out-of-memory condition can no longer
+   desynchronize the cache from the system: the only allocation left is the one that
+   describes an arriving device, and failing it simply does not cache the device
+   (nothing was reported for it either - see hid_internal_notify_callback).
+
+   The comparison is case-independent for ASCII, exactly like the _stricmp() it
+   replaces. A cached path is always a WC_ERR_INVALID_CHARS conversion of an
+   interface path (see hid_internal_UTF16toUTF8 and hid_internal_get_device_info),
+   so it always encodes well-formed UTF-16: an ill-formed symbolic link cannot be in
+   the cache, and comparing unequal is the correct answer for it - which is what the
+   failing conversion used to yield as well. */
+static int hid_internal_path_equals(const char *cached_path, const wchar_t *interface_path)
+{
+	const unsigned char *cached = (const unsigned char *)cached_path;
+
+	while (*interface_path != L'\0') {
+		unsigned long code_point = (unsigned long)*interface_path++;
+		unsigned char utf8[4];
+		size_t len, i;
+
+		if (code_point >= 0xD800UL && code_point <= 0xDBFFUL) {
+			/* A high surrogate must be followed by a low one */
+			if (*interface_path < 0xDC00 || *interface_path > 0xDFFF) {
+				return 0;
+			}
+			code_point = 0x10000UL + ((code_point - 0xD800UL) << 10) + (unsigned long)(*interface_path++ - 0xDC00);
+		} else if (code_point >= 0xDC00UL && code_point <= 0xDFFFUL) {
+			/* An unpaired low surrogate */
+			return 0;
+		}
+
+		if (code_point < 0x80UL) {
+			utf8[0] = (unsigned char)code_point;
+			len = 1;
+		} else if (code_point < 0x800UL) {
+			utf8[0] = (unsigned char)(0xC0UL | (code_point >> 6));
+			utf8[1] = (unsigned char)(0x80UL | (code_point & 0x3FUL));
+			len = 2;
+		} else if (code_point < 0x10000UL) {
+			utf8[0] = (unsigned char)(0xE0UL | (code_point >> 12));
+			utf8[1] = (unsigned char)(0x80UL | ((code_point >> 6) & 0x3FUL));
+			utf8[2] = (unsigned char)(0x80UL | (code_point & 0x3FUL));
+			len = 3;
+		} else {
+			utf8[0] = (unsigned char)(0xF0UL | (code_point >> 18));
+			utf8[1] = (unsigned char)(0x80UL | ((code_point >> 12) & 0x3FUL));
+			utf8[2] = (unsigned char)(0x80UL | ((code_point >> 6) & 0x3FUL));
+			utf8[3] = (unsigned char)(0x80UL | (code_point & 0x3FUL));
+			len = 4;
+		}
+
+		/* No byte of an encoded code point is ever '\0', so a cached path that ends
+		   early simply compares unequal here: the walk cannot run past its end */
+		for (i = 0; i < len; ++i) {
+			if (hid_internal_ascii_tolower(*cached) != hid_internal_ascii_tolower(utf8[i])) {
+				return 0;
+			}
+			++cached;
+		}
+	}
+
+	return *cached == '\0';
+}
+
 /* Tells whether an interface path is already in the device cache - i.e. whether
    its connection has already been reported. Always called inside a locked mutex.
 
@@ -804,11 +885,11 @@ static void hid_internal_hotplug_pin_module(void)
    by construction, already put the device in the cache. Conversely the removal
    notification is authoritative and drops the cache entry, so a genuine re-plug
    (even onto the same, reused path) is NOT cached and IS reported. */
-static int hid_internal_hotplug_is_cached(const char *path)
+static int hid_internal_hotplug_is_cached(const wchar_t *interface_path)
 {
 	for (struct hid_device_info *device = hid_hotplug_context.devs; device != NULL; device = device->next) {
 		/* Case-independent path comparison is mandatory */
-		if (device->path != NULL && _stricmp(device->path, path) == 0) {
+		if (device->path != NULL && hid_internal_path_equals(device->path, interface_path)) {
 			return 1;
 		}
 	}
@@ -816,13 +897,14 @@ static int hid_internal_hotplug_is_cached(const char *path)
 	return 0;
 }
 
-/* Unlinks the cached device with this path, if there is one, and hands it to the
-   caller (who owns it). Always called inside a locked mutex. */
-static struct hid_device_info *hid_internal_hotplug_take_cached_device(const char *path)
+/* Unlinks the cached device with this interface path, if there is one, and hands
+   it to the caller (who owns it). Always called inside a locked mutex. Allocates
+   nothing: see hid_internal_path_equals. */
+static struct hid_device_info *hid_internal_hotplug_take_cached_device(const wchar_t *interface_path)
 {
 	for (struct hid_device_info **current = &hid_hotplug_context.devs; *current != NULL; current = &(*current)->next) {
 		/* Case-independent path comparison is mandatory */
-		if ((*current)->path != NULL && _stricmp((*current)->path, path) == 0) {
+		if ((*current)->path != NULL && hid_internal_path_equals((*current)->path, interface_path)) {
 			struct hid_device_info *device = *current;
 			*current = device->next;
 			device->next = NULL;
@@ -1871,14 +1953,9 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
 	if (action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL) {
-		char *path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink, NULL);
-
 		hotplug_event = HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED;
 
-		if (path == NULL) {
-			/* Out of memory: there is nothing to report the connection with, and
-			   nothing is cached, so the cache stays consistent */
-		} else if (hid_internal_hotplug_is_cached(path)) {
+		if (hid_internal_hotplug_is_cached(event_data->u.DeviceInterface.SymbolicLink)) {
 			/* This connection is already known - and therefore already reported.
 			   The only way that happens is the arm-before-enumerate window at
 			   registration, where the enumeration cached the device and the OS had
@@ -1915,24 +1992,16 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 			   report it with; the cache is left consistent either way, as only fully
 			   described devices are ever cached. */
 		}
-
-		free(path);
 	} else if (action == CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL) {
-		char *path;
-
 		hotplug_event = HID_API_HOTPLUG_EVENT_DEVICE_LEFT;
 
-		path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink, NULL);
-
-		if (path != NULL) {
-			/* Get and remove this device from the device list. Dropping the entry is
-			   what makes a later arrival on the same path (an interface path is
-			   reused when a device is replugged into the same port) a new connection
-			   rather than a duplicate - see hid_internal_hotplug_is_cached. */
-			device = hid_internal_hotplug_take_cached_device(path);
-
-			free(path);
-		}
+		/* Get and remove this device from the device list. Dropping the entry is
+		   what makes a later arrival on the same path (an interface path is reused
+		   when a device is replugged into the same port) a new connection rather
+		   than a duplicate - see hid_internal_hotplug_is_cached. The lookup cannot
+		   fail for lack of memory (it allocates nothing), so a removal can never
+		   leave its record behind. */
+		device = hid_internal_hotplug_take_cached_device(event_data->u.DeviceInterface.SymbolicLink);
 	}
 
 	if (device) {

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -476,7 +476,12 @@ static wchar_t *last_global_error_str = NULL;
    must be true for the dispatching thread alone, never for a concurrent
    application thread. This is how mac/libusb detect the event context (they
    compare its thread identity). */
-static __declspec(thread) int hid_in_hotplug_callback = 0;
+#if defined(_MSC_VER)
+#define HID_THREAD_LOCAL __declspec(thread)
+#else
+#define HID_THREAD_LOCAL __thread /* GCC/Clang (MinGW, Cygwin): __declspec(thread) is ignored there */
+#endif
+static HID_THREAD_LOCAL int hid_in_hotplug_callback = 0;
 
 /* Serializes mutations of last_global_error_str: the hotplug API is
    thread-safe and its failure paths may write the global error concurrently.

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -127,6 +127,12 @@ static CM_Get_DevNode_PropertyW_ CM_Get_DevNode_PropertyW = NULL;
 static CM_Get_Device_Interface_PropertyW_ CM_Get_Device_Interface_PropertyW = NULL;
 static CM_Get_Device_Interface_List_SizeW_ CM_Get_Device_Interface_List_SizeW = NULL;
 static CM_Get_Device_Interface_ListW_ CM_Get_Device_Interface_ListW = NULL;
+
+/* Windows 8 and up: NOT resolved by lookup_functions() - that one is mandatory
+   and would fail hid_init() itself on older Windows, taking the whole library
+   down for everyone, including those that never touch hotplug. Resolved on the
+   first hotplug registration instead, and only there
+   (see hid_internal_hotplug_resolve_cm_notification). */
 static CM_Register_Notification_ CM_Register_Notification = NULL;
 static CM_Unregister_Notification_ CM_Unregister_Notification = NULL;
 
@@ -142,6 +148,11 @@ static void free_library_handles()
 	if (cfgmgr32_lib_handle)
 		FreeLibrary(cfgmgr32_lib_handle);
 	cfgmgr32_lib_handle = NULL;
+	/* Lazily resolved (see above): unlike the pointers lookup_functions() resolves
+	   unconditionally, nothing re-resolves these on the next hid_init() unless
+	   they are cleared here */
+	CM_Register_Notification = NULL;
+	CM_Unregister_Notification = NULL;
 }
 
 static int lookup_functions()
@@ -185,8 +196,6 @@ static int lookup_functions()
 	RESOLVE(cfgmgr32_lib_handle, CM_Get_Device_Interface_PropertyW);
 	RESOLVE(cfgmgr32_lib_handle, CM_Get_Device_Interface_List_SizeW);
 	RESOLVE(cfgmgr32_lib_handle, CM_Get_Device_Interface_ListW);
-	RESOLVE(cfgmgr32_lib_handle, CM_Register_Notification);
-	RESOLVE(cfgmgr32_lib_handle, CM_Unregister_Notification);
 
 #undef RESOLVE
 
@@ -438,7 +447,8 @@ static void register_string_error(hid_device *dev, const WCHAR *string_error)
    using them would turn hidapi into a load-time importer of Vista-only kernel32
    symbols - for every user of the library, including those that never touch
    hotplug. Everything this file uses above its minimum target is resolved
-   dynamically instead (see lookup_functions and hid_internal_hotplug_resolve_threadpool).
+   dynamically instead (see lookup_functions, hid_internal_hotplug_resolve_threadpool
+   and hid_internal_hotplug_resolve_cm_notification).
    The regions guarded by this lock are kept deliberately small - pointer swaps
    and flag/counter updates; the one-time bootstrap of the hotplug machinery is
    the largest. */
@@ -477,11 +487,95 @@ static wchar_t *last_global_error_str = NULL;
    application thread. This is how mac/libusb detect the event context (they
    compare its thread identity). */
 #if defined(_MSC_VER)
-#define HID_THREAD_LOCAL __declspec(thread)
+/* Dynamic TLS (a TlsAlloc'd index), NOT __declspec(thread): implicit TLS in a DLL
+   is only set up by the loader from Windows Vista on, so an MSVC-built hidapi.dll
+   that an older Windows LoadLibrary's would read a slot that does not exist -
+   defeating the very load floor the dynamic resolution above maintains.
+   TlsAlloc/TlsGetValue/TlsSetValue are ancient kernel32 exports, so unlike
+   everything else here they need no GetProcAddress.
+   The index is allocated on the hotplug bootstrap (see
+   hid_internal_hotplug_init_under_lock), so a process that never registers a
+   hotplug callback never spends one, and it is never freed - like the critical
+   section a leaked notification can still enter, a late event context must still
+   find its slot, and one index per process is all this ever needs. */
+static DWORD hid_in_hotplug_callback_tls = TLS_OUT_OF_INDEXES;
+
+/* Allocates that index. Must be called with hotplug_init_lock held (which is
+   what publishes it), and is a no-op once it succeeded. */
+static int hid_internal_hotplug_alloc_tls(void)
+{
+	DWORD index;
+
+	if (hid_in_hotplug_callback_tls != TLS_OUT_OF_INDEXES) {
+		return 0;
+	}
+
+	index = TlsAlloc();
+	if (index == TLS_OUT_OF_INDEXES) {
+		return -1;
+	}
+
+	hid_in_hotplug_callback_tls = index;
+
+	return 0;
+}
+
+static int hid_internal_in_hotplug_callback(void)
+{
+	DWORD index = hid_in_hotplug_callback_tls;
+	DWORD error;
+	int in_callback;
+
+	/* No index yet: hotplug has never been bootstrapped, so no thread can be
+	   inside a callback - "not allocated" simply reads as 0. Keeps this cheap and
+	   safe on every global error path, hid_init()'s included. A plain read is
+	   enough: the index is published before anything can run on the event context,
+	   and it never changes again. */
+	if (index == TLS_OUT_OF_INDEXES) {
+		return 0;
+	}
+
+	/* TlsGetValue clears the thread's last error on success: preserve it, so that
+	   reading the flag stays as invisible to the caller as reading a variable was */
+	error = GetLastError();
+	in_callback = (TlsGetValue(index) != NULL);
+	SetLastError(error);
+
+	return in_callback;
+}
+
+static void hid_internal_set_in_hotplug_callback(int in_callback)
+{
+	DWORD index = hid_in_hotplug_callback_tls;
+
+	if (index == TLS_OUT_OF_INDEXES) {
+		/* Unreachable: the event context only exists once the bootstrap allocated
+		   the index */
+		return;
+	}
+
+	TlsSetValue(index, in_callback ? (PVOID)(UINT_PTR)1 : NULL);
+}
 #else
-#define HID_THREAD_LOCAL __thread /* GCC/Clang (MinGW, Cygwin): __declspec(thread) is ignored there */
+/* GCC/Clang (MinGW, Cygwin): __declspec(thread) is ignored there, and their
+   emulated TLS has none of the loader problem described above */
+static __thread int hid_in_hotplug_callback = 0;
+
+static int hid_internal_hotplug_alloc_tls(void)
+{
+	return 0;
+}
+
+static int hid_internal_in_hotplug_callback(void)
+{
+	return hid_in_hotplug_callback;
+}
+
+static void hid_internal_set_in_hotplug_callback(int in_callback)
+{
+	hid_in_hotplug_callback = in_callback;
+}
 #endif
-static HID_THREAD_LOCAL int hid_in_hotplug_callback = 0;
 
 /* Serializes mutations of last_global_error_str: the hotplug API is
    thread-safe and its failure paths may write the global error concurrently.
@@ -491,7 +585,7 @@ static HID_THREAD_LOCAL int hid_in_hotplug_callback = 0;
    against the hotplug API. HIDAPI's own code on the internal event context
    never writes the global error - not even a user callback that re-enters the
    public hotplug API from that context: register_global_error_message() drops
-   those writes (see hid_in_hotplug_callback). An application therefore never
+   those writes (see hid_internal_in_hotplug_callback). An application therefore never
    has to serialize hid_error(NULL) against a write it could not see coming,
    matching the other backends (libusb, linux, mac). */
 static hid_internal_lock global_error_lock = 0;
@@ -508,11 +602,11 @@ static void register_global_error_message(wchar_t *msg)
 	   made from such a callback must not touch last_global_error_str - success
 	   clear included: the write happens on the event context, and the
 	   application cannot serialize its lock-free hid_error(NULL) read against it.
-	   hid_in_hotplug_callback is thread-local and set only around the callback
-	   invocation, so this drops writes on the dispatching thread alone. A
-	   concurrent application thread (its own flag is 0) still records its errors,
-	   and reading a thread-local is not a shared-memory data race. */
-	if (hid_in_hotplug_callback) {
+	   The flag is thread-local and set only around the callback invocation, so
+	   this drops writes on the dispatching thread alone. A concurrent application
+	   thread (its own flag is 0) still records its errors, and reading a
+	   thread-local is not a shared-memory data race. */
+	if (hid_internal_in_hotplug_callback()) {
 		free(msg);
 		return;
 	}
@@ -635,26 +729,77 @@ static int hid_internal_hotplug_resolve_threadpool(void)
 	return 0;
 }
 
+/* Resolves the PnP notification API that delivers the hotplug events. Windows 8
+   and up, so - like the threadpool API above - it is resolved here and not in
+   the mandatory lookup_functions(): a failure there would fail hid_init() as a
+   whole on older Windows. Always called inside the critical section (which is
+   also what keeps it from racing the hid_exit() that unloads cfgmgr32.dll).
+   Returns -1 when the API is unavailable (the OS predates it), in which case
+   hotplug is not available either. */
+static int hid_internal_hotplug_resolve_cm_notification(void)
+{
+#ifdef HIDAPI_USE_DDK
+	/* Statically imported from cfgmgr32.lib in this build */
+	return 0;
+#else
+	if (CM_Unregister_Notification != NULL) {
+		/* Already resolved: resolved last, so it doubles as the "all set" flag */
+		return 0;
+	}
+
+	if (cfgmgr32_lib_handle == NULL) {
+		/* hid_init() has not run (or hid_exit() unloaded the library again) */
+		return -1;
+	}
+
+/* Avoid direct function-pointer cast from FARPROC to typed callback pointer.
+   Using memcpy keeps this warning-free regardless of the compiler and compiler settings. */
+#define RESOLVE_CM(x) do { \
+	FARPROC proc_addr = GetProcAddress(cfgmgr32_lib_handle, #x); \
+	if (!proc_addr) return -1; \
+	memcpy(&x, &proc_addr, sizeof(x)); \
+} while (0)
+
+	RESOLVE_CM(CM_Register_Notification);
+	RESOLVE_CM(CM_Unregister_Notification);
+
+#undef RESOLVE_CM
+
+	return 0;
+#endif
+}
+
 /* Bootstraps the hotplug machinery: the critical section that guards all
-   hotplug state and the manual-reset quiescence event. Must be called with
-   hotplug_init_lock held. On failure nothing is created and *create_error
-   receives the CreateEvent error code (reporting it is left to the caller:
-   this runs under a spinlock).
+   hotplug state, the manual-reset quiescence event and the event-context marker.
+   Must be called with hotplug_init_lock held. On failure the machinery is not
+   created and *create_error / *create_op receive the error code and the name of
+   the call that failed (reporting them is left to the caller: this runs under a
+   spinlock).
    Once created, the machinery stays valid for as long as anything can enter it:
    hid_exit() destroys it only after proving nothing can (see
    hid_internal_hotplug_enter and hid_internal_hotplug_exit), and when a
    notification could not be unregistered it is never destroyed at all, so that
    a live OS callback can never enter a deleted critical section. */
-static int hid_internal_hotplug_init_under_lock(DWORD *create_error)
+static int hid_internal_hotplug_init_under_lock(DWORD *create_error, const WCHAR **create_op)
 {
 	if (hid_hotplug_context.mutex_ready) {
 		return 0;
+	}
+
+	/* The event-context marker's slot: only a process that uses hotplug spends
+	   one, and it outlives the machinery on purpose (see
+	   hid_in_hotplug_callback_tls) */
+	if (hid_internal_hotplug_alloc_tls() < 0) {
+		*create_error = GetLastError();
+		*create_op = L"hid_hotplug_register_callback/TlsAlloc";
+		return -1;
 	}
 
 	/* Manual reset, initially signaled: nothing is pending yet */
 	hid_hotplug_context.quiescent_event = CreateEvent(NULL, TRUE, TRUE, NULL);
 	if (hid_hotplug_context.quiescent_event == NULL) {
 		*create_error = GetLastError();
+		*create_op = L"hid_hotplug_register_callback/CreateEvent";
 		return -1;
 	}
 
@@ -688,13 +833,14 @@ static int hid_internal_hotplug_enter(int bootstrap)
 {
 	int result = 0;
 	DWORD create_error = 0;
+	const WCHAR *create_op = NULL;
 
 	hid_internal_lock_acquire(&hotplug_init_lock);
 	if (hotplug_exiting) {
 		result = HID_HOTPLUG_ENTER_EXITING;
 	} else if (!bootstrap && !hid_hotplug_context.mutex_ready) {
 		result = HID_HOTPLUG_ENTER_NOT_READY;
-	} else if (hid_internal_hotplug_init_under_lock(&create_error) < 0) {
+	} else if (hid_internal_hotplug_init_under_lock(&create_error, &create_op) < 0) {
 		result = HID_HOTPLUG_ENTER_FAILED;
 	} else {
 		hotplug_machinery_users++;
@@ -702,7 +848,7 @@ static int hid_internal_hotplug_enter(int bootstrap)
 	hid_internal_lock_release(&hotplug_init_lock);
 
 	if (result == HID_HOTPLUG_ENTER_FAILED) {
-		register_global_winapi_error_code(create_error, L"hid_hotplug_register_callback/CreateEvent");
+		register_global_winapi_error_code(create_error, create_op);
 	}
 
 	return result;
@@ -914,7 +1060,19 @@ static int hid_internal_path_equals(const char *cached_path, const wchar_t *inte
    only way an arrival can be a duplicate - and in that case the enumeration has,
    by construction, already put the device in the cache. Conversely the removal
    notification is authoritative and drops the cache entry, so a genuine re-plug
-   (even onto the same, reused path) is NOT cached and IS reported. */
+   (even onto the same, reused path) is NOT cached and IS reported.
+
+   That last step does assume the OS dispatches ONE registration's notifications
+   sequentially, i.e. in delivery order. If a removal and the arrival of a re-plug
+   onto the same path were ever dispatched concurrently, the arrival could observe
+   the cache entry the removal has not dropped yet, be mistaken for the arm-window
+   duplicate above and be dropped whole - after which the removal drops the stale
+   entry, and the new connection is reported neither ARRIVED nor LEFT. MSDN
+   documents no such ordering guarantee for CM_Register_Notification, but the CM
+   machinery does dispatch a registration's events sequentially in practice.
+   Making this independent of the OS would mean queueing the raw events in a FIFO
+   and draining it from the (single) work item; not worth it for a hazard nothing
+   has been observed to produce. */
 static int hid_internal_hotplug_is_cached(const wchar_t *interface_path)
 {
 	for (struct hid_device_info *device = hid_hotplug_context.devs; device != NULL; device = device->next) {
@@ -980,6 +1138,9 @@ static void hid_internal_hotplug_finish_unregistration(HCMNOTIFICATION notify_ha
 	CONFIGRET cr;
 
 	if (notify_handle == NULL) {
+		/* Nothing was detached - and on a teardown that never armed a notification
+		   CM_Unregister_Notification is not even resolved: a handle can only exist
+		   once it is (see hid_internal_hotplug_resolve_cm_notification) */
 		return;
 	}
 
@@ -1085,10 +1246,10 @@ static void hid_internal_hotplug_replay_flush(struct hid_hotplug_callback *callb
 		/* Mark this thread as the event context for the duration of the call, so a
 		   nested public hotplug call does not write the global error (save/restore
 		   keeps nested callbacks composing correctly). */
-		int prev_in_cb = hid_in_hotplug_callback;
-		hid_in_hotplug_callback = 1;
+		int prev_in_cb = hid_internal_in_hotplug_callback();
+		hid_internal_set_in_hotplug_callback(1);
 		int result = (*callback->callback)(callback->handle, device, HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED, callback->user_data);
-		hid_in_hotplug_callback = prev_in_cb;
+		hid_internal_set_in_hotplug_callback(prev_in_cb);
 		hid_free_enumeration(device);
 
 		/* A non-zero result stops the remainder of the pass and deregisters the callback */
@@ -1955,11 +2116,11 @@ static void hid_internal_hotplug_dispatch(struct hid_device_info *device, hid_ho
 
 		if ((callback->events & hotplug_event) && hid_internal_match_device_id(device->vendor_id, device->product_id, callback->vendor_id, callback->product_id)) {
 			/* Mark this thread as the event context for the duration of the call
-			   (see hid_in_hotplug_callback); save/restore for nested callbacks. */
-			int prev_in_cb = hid_in_hotplug_callback;
-			hid_in_hotplug_callback = 1;
+			   (see hid_internal_in_hotplug_callback); save/restore for nested callbacks. */
+			int prev_in_cb = hid_internal_in_hotplug_callback();
+			hid_internal_set_in_hotplug_callback(1);
 			int result = (callback->callback)(callback->handle, device, hotplug_event, callback->user_data);
-			hid_in_hotplug_callback = prev_in_cb;
+			hid_internal_set_in_hotplug_callback(prev_in_cb);
 
 			/* If the result is non-zero, we MARK the callback for future removal and proceed */
 			/* We avoid changing the list until we are done calling the callbacks to simplify the process */
@@ -1977,7 +2138,7 @@ static void hid_internal_hotplug_dispatch(struct hid_device_info *device, hid_ho
 	hid_hotplug_context.mutex_in_use = 0;
 }
 
-DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context, CM_NOTIFY_ACTION action, PCM_NOTIFY_EVENT_DATA event_data, DWORD event_data_size)
+static DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context, CM_NOTIFY_ACTION action, PCM_NOTIFY_EVENT_DATA event_data, DWORD event_data_size)
 {
 	struct hid_device_info *device = NULL;
 	hid_hotplug_event hotplug_event = (hid_hotplug_event)0;
@@ -2144,6 +2305,13 @@ static int hid_internal_hotplug_register_counted(struct hid_hotplug_callback *ho
 
 		if (hid_internal_hotplug_resolve_threadpool() < 0) {
 			register_global_error(L"Hotplug is not supported: the threadpool API is unavailable");
+			LeaveCriticalSection(&hid_hotplug_context.critical_section);
+			free(hotplug_cb);
+			return -1;
+		}
+
+		if (hid_internal_hotplug_resolve_cm_notification() < 0) {
+			register_global_error(L"Hotplug is not supported: the PnP notification API is unavailable");
 			LeaveCriticalSection(&hid_hotplug_context.critical_section);
 			free(hotplug_cb);
 			return -1;

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -66,6 +66,7 @@ typedef LONG NTSTATUS;
 #include "hidapi_hidclass.h"
 #include "hidapi_hidsdi.h"
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -234,6 +235,20 @@ static struct hid_hotplug_context {
 	   Created with the first callback registration, closed by hid_exit(). */
 	PTP_WORK event_work;
 
+	/* Number of notification handles detached from the context whose
+	   CM_Unregister_Notification call has not completed yet, and the condition
+	   used to wait for that to drop to zero (a zero-initialized
+	   CONDITION_VARIABLE is valid). Guarded by the critical section.
+	   A new notification is only armed once this is zero: the OS keeps a
+	   detached handle live until the unregistration completes, and two live
+	   registrations would deliver every event twice. */
+	LONG pending_unregistrations;
+	CONDITION_VARIABLE unregistration_cv;
+
+	/* Set when CM_Unregister_Notification failed: the OS-side registration may
+	   still be live, so the state its callbacks can touch is never destroyed */
+	unsigned char unregistration_failed;
+
 	/* Critical section (faster mutex substitute), for both cached device list and callback list changes */
 	CRITICAL_SECTION critical_section;
 
@@ -389,14 +404,22 @@ static void register_string_error(hid_device *dev, const WCHAR *string_error)
 
 static wchar_t *last_global_error_str = NULL;
 
+/* Serializes mutations of last_global_error_str: the hotplug API is
+   thread-safe and its failure paths may write the global error concurrently */
+static SRWLOCK global_error_lock = SRWLOCK_INIT;
+
 static void register_global_winapi_error(const WCHAR *op)
 {
+	AcquireSRWLockExclusive(&global_error_lock);
 	register_winapi_error_to_buffer(&last_global_error_str, op);
+	ReleaseSRWLockExclusive(&global_error_lock);
 }
 
 static void register_global_error(const WCHAR *string_error)
 {
+	AcquireSRWLockExclusive(&global_error_lock);
 	register_string_error_to_buffer(&last_global_error_str, string_error);
+	ReleaseSRWLockExclusive(&global_error_lock);
 }
 
 static HANDLE open_device(const wchar_t *path, BOOL open_rw)
@@ -426,8 +449,13 @@ HID_API_EXPORT const char* HID_API_CALL hid_version_str(void)
 	return HID_API_VERSION_STR;
 }
 
+/* Serializes the bootstrap of the hotplug machinery: two racing first
+   registrations must not both initialize the critical section */
+static SRWLOCK hotplug_init_lock = SRWLOCK_INIT;
+
 static void hid_internal_hotplug_init()
 {
+	AcquireSRWLockExclusive(&hotplug_init_lock);
 	if (!hid_hotplug_context.mutex_ready) {
 		InitializeCriticalSection(&hid_hotplug_context.critical_section);
 
@@ -435,9 +463,11 @@ static void hid_internal_hotplug_init()
 		hid_hotplug_context.mutex_ready = 1;
 		hid_hotplug_context.mutex_in_use = 0;
 		hid_hotplug_context.cb_list_dirty = 0;
+		hid_hotplug_context.pending_unregistrations = 0;
 		if (hid_hotplug_context.next_handle < FIRST_HOTPLUG_CALLBACK_HANDLE)
 			hid_hotplug_context.next_handle = FIRST_HOTPLUG_CALLBACK_HANDLE;
 	}
+	ReleaseSRWLockExclusive(&hotplug_init_lock);
 }
 
 int HID_API_EXPORT hid_init(void)
@@ -526,24 +556,43 @@ static void hid_internal_hotplug_remove_postponed()
 	hid_hotplug_context.cb_list_dirty = 0;
 }
 
-static void hid_internal_hotplug_unregister_notification(HCMNOTIFICATION notify_handle)
+/* Completes the unregistration of a notification handle detached by
+   hid_internal_hotplug_cleanup. Must be called OUTSIDE the critical section:
+   CM_Unregister_Notification waits for in-progress notification callbacks,
+   which may themselves be blocked on the critical section. */
+static void hid_internal_hotplug_finish_unregistration(HCMNOTIFICATION notify_handle)
 {
+	CONFIGRET cr;
+
 	if (notify_handle == NULL) {
 		return;
 	}
 
-	if (CM_Unregister_Notification(notify_handle) != CR_SUCCESS) {
+	cr = CM_Unregister_Notification(notify_handle);
+
+	EnterCriticalSection(&hid_hotplug_context.critical_section);
+	if (cr != CR_SUCCESS) {
+		/* The OS-side registration may still be live: taint the epoch so
+		   hid_exit() never destroys the state a late notification can touch */
+		hid_hotplug_context.unregistration_failed = 1;
+	}
+	hid_hotplug_context.pending_unregistrations--;
+	if (hid_hotplug_context.pending_unregistrations == 0) {
+		WakeAllConditionVariable(&hid_hotplug_context.unregistration_cv);
+	}
+	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+	if (cr != CR_SUCCESS) {
 		register_global_error(L"CM_Unregister_Notification failed for Hotplug notification");
 	}
 }
 
 /* Always called inside a locked mutex.
    When the last callback is gone, tears the machinery down and returns the
-   Win32 notification handle: CM_Unregister_Notification waits for in-progress
-   notification callbacks, which in turn may be blocked on our critical
-   section, so the caller must invoke it only after leaving the critical
-   section (and never from the notification callback itself: the notification
-   callback defers the teardown to the threadpool work item instead). */
+   Win32 notification handle, which the caller MUST hand to
+   hid_internal_hotplug_finish_unregistration after leaving the critical
+   section (never under it, and never from the notification callback itself:
+   the notification callback defers the teardown to the threadpool work item). */
 static HCMNOTIFICATION hid_internal_hotplug_cleanup()
 {
 	HCMNOTIFICATION notify_handle;
@@ -568,6 +617,10 @@ static HCMNOTIFICATION hid_internal_hotplug_cleanup()
 
 	notify_handle = hid_hotplug_context.notify_handle;
 	hid_hotplug_context.notify_handle = NULL;
+	if (notify_handle != NULL) {
+		/* Balanced by hid_internal_hotplug_finish_unregistration */
+		hid_hotplug_context.pending_unregistrations++;
+	}
 	return notify_handle;
 }
 
@@ -622,16 +675,17 @@ static VOID CALLBACK hid_internal_hotplug_event_work(PTP_CALLBACK_INSTANCE insta
 
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
-	hid_internal_hotplug_unregister_notification(notify_handle);
+	hid_internal_hotplug_finish_unregistration(notify_handle);
 }
 
-static void hid_internal_hotplug_exit()
+static int hid_internal_hotplug_exit()
 {
 	HCMNOTIFICATION notify_handle;
+	int failed_epoch;
 
 	if (!hid_hotplug_context.mutex_ready) {
 		/* If the critical section is not initialized, we are safe to assume nothing else is */
-		return;
+		return 0;
 	}
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 	struct hid_hotplug_callback **current = &hid_hotplug_context.hotplug_cbs;
@@ -645,7 +699,29 @@ static void hid_internal_hotplug_exit()
 	notify_handle = hid_internal_hotplug_cleanup();
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
-	hid_internal_hotplug_unregister_notification(notify_handle);
+	hid_internal_hotplug_finish_unregistration(notify_handle);
+
+	/* Quiescence: unregistrations started by concurrent (contract-legal)
+	   hid_hotplug_deregister_callback calls must complete before the state
+	   their notifications can still touch is destroyed. The sleep releases
+	   the critical section while waiting. */
+	EnterCriticalSection(&hid_hotplug_context.critical_section);
+	while (hid_hotplug_context.pending_unregistrations > 0) {
+		if (!SleepConditionVariableCS(&hid_hotplug_context.unregistration_cv, &hid_hotplug_context.critical_section, INFINITE)) {
+			/* Should never happen; treat like a failed unregistration rather than spinning */
+			break;
+		}
+	}
+	failed_epoch = (hid_hotplug_context.unregistration_failed != 0) || (hid_hotplug_context.pending_unregistrations > 0);
+	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+	if (failed_epoch) {
+		/* At least one notification may still be live at the OS level: keep the
+		   critical section and the work item alive (deliberately leaked), so a
+		   late callback touches valid, empty state instead of freed memory */
+		register_global_error(L"hid_exit: a hotplug notification could not be unregistered");
+		return -1;
+	}
 
 	if (hid_hotplug_context.event_work) {
 		/* Wait for any in-flight work item before the critical section goes away.
@@ -664,11 +740,19 @@ static void hid_internal_hotplug_exit()
 
 	hid_hotplug_context.mutex_ready = 0;
 	DeleteCriticalSection(&hid_hotplug_context.critical_section);
+
+	return 0;
 }
 
 int HID_API_EXPORT hid_exit(void)
 {
-    hid_internal_hotplug_exit();
+	if (hid_internal_hotplug_exit() < 0) {
+		/* A hotplug notification could not be unregistered and may still fire:
+		   keep the resolved DLLs loaded (deliberately leaked) so a late
+		   callback does not call into unloaded code.
+		   register_global_error: set by hid_internal_hotplug_exit */
+		return -1;
+	}
 
 #ifndef HIDAPI_USE_DDK
 	free_library_handles();
@@ -909,7 +993,9 @@ static hid_internal_detect_bus_type_result hid_internal_detect_bus_type(const wc
 	wchar_t *device_id = NULL, *compatible_ids = NULL;
 	CONFIGRET cr;
 	DEVINST dev_node;
-	hid_internal_detect_bus_type_result result = { 0 };
+	hid_internal_detect_bus_type_result result;
+
+	memset(&result, 0, sizeof(result));
 
 	/* Get the device id from interface path */
 	device_id = (wchar_t *)hid_internal_get_device_interface_property(interface_path, &DEVPKEY_Device_InstanceId, DEVPROP_TYPE_STRING);
@@ -1099,7 +1185,9 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 	return dev;
 }
 
-struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+/* Same as hid_enumerate, but distinguishes a genuine failure (*failure set
+   to 1, error registered) from an empty result (NULL with *failure left 0) */
+static struct hid_device_info *hid_internal_enumerate(unsigned short vendor_id, unsigned short product_id, int *failure)
 {
 	struct hid_device_info *root = NULL; /* return object */
 	struct hid_device_info *cur_dev = NULL;
@@ -1107,6 +1195,8 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 	CONFIGRET cr;
 	wchar_t* device_interface_list = NULL;
 	DWORD len;
+
+	*failure = 1;
 
 	if (hid_init() < 0) {
 		/* register_global_error: global error is reset by hid_init */
@@ -1145,6 +1235,8 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 	if (cr != CR_SUCCESS) {
 		goto end_of_function;
 	}
+
+	*failure = 0;
 
 	/* Iterate over each device interface in the HID class, looking for the right one. */
 	for (wchar_t* device_interface = device_interface_list; *device_interface; device_interface += wcslen(device_interface) + 1) {
@@ -1203,6 +1295,12 @@ end_of_function:
 	return root;
 }
 
+struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+{
+	int failure = 0;
+	return hid_internal_enumerate(vendor_id, product_id, &failure);
+}
+
 void  HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info *devs)
 {
 	/* TODO: Merge this with the Linux version. This function is platform-independent. */
@@ -1235,29 +1333,49 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
 	if (action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL) {
-		HANDLE read_handle;
+		char *path;
+		int known = 0;
 
 		hotplug_event = HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED;
 
-		/* Open read-only handle to the device */
-		read_handle = open_device(event_data->u.DeviceInterface.SymbolicLink, FALSE);
-
-		/* Check validity of read_handle. */
-		if (read_handle != INVALID_HANDLE_VALUE) {
-			device = hid_internal_get_device_info(event_data->u.DeviceInterface.SymbolicLink, read_handle);
-
-			/* Append to the end of the device list */
-			if (hid_hotplug_context.devs != NULL) {
-				struct hid_device_info *last = hid_hotplug_context.devs;
-				while (last->next != NULL) {
-					last = last->next;
+		/* An arrival for a path already in the cache is a duplicate: the
+		   registration-time enumeration overlaps with the already-armed
+		   notification, and a notification being unregistered may briefly
+		   coexist with its replacement. Deduplicating here keeps each
+		   connection reported (and cached) exactly once. */
+		path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink);
+		if (path != NULL) {
+			for (struct hid_device_info *current = hid_hotplug_context.devs; current != NULL; current = current->next) {
+				/* Case-independent path comparison is mandatory */
+				if (current->path != NULL && _stricmp(current->path, path) == 0) {
+					known = 1;
+					break;
 				}
-				last->next = device;
-			} else {
-				hid_hotplug_context.devs = device;
 			}
+			free(path);
+		}
 
-			CloseHandle(read_handle);
+		if (!known) {
+			/* Open read-only handle to the device */
+			HANDLE read_handle = open_device(event_data->u.DeviceInterface.SymbolicLink, FALSE);
+
+			/* Check validity of read_handle. */
+			if (read_handle != INVALID_HANDLE_VALUE) {
+				device = hid_internal_get_device_info(event_data->u.DeviceInterface.SymbolicLink, read_handle);
+
+				/* Append to the end of the device list */
+				if (hid_hotplug_context.devs != NULL) {
+					struct hid_device_info *last = hid_hotplug_context.devs;
+					while (last->next != NULL) {
+						last = last->next;
+					}
+					last->next = device;
+				} else {
+					hid_hotplug_context.devs = device;
+				}
+
+				CloseHandle(read_handle);
+			}
 		}
 	} else if (action == CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL) {
 		char *path;
@@ -1385,12 +1503,27 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	/* Lock the mutex to avoid race conditions */
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
+	/* Handle values are never reused while the library remains initialized */
+	if (hid_hotplug_context.next_handle >= INT_MAX) {
+		LeaveCriticalSection(&hid_hotplug_context.critical_section);
+		free(hotplug_cb);
+		register_global_error(L"Hotplug callback handles exhausted");
+		return -1;
+	}
 	hotplug_cb->handle = hid_hotplug_context.next_handle++;
 
-	/* handle the unlikely case of handle overflow */
-	if (hid_hotplug_context.next_handle < 0)
-	{
-		hid_hotplug_context.next_handle = 1;
+	/* A notification detached by a concurrent deregistration may still be live
+	   at the OS until its unregistration completes; arming a replacement in
+	   that window would deliver every event twice. The sleep releases the
+	   critical section, so on wake the state is re-evaluated from scratch. */
+	while (hid_hotplug_context.hotplug_cbs == NULL && hid_hotplug_context.notify_handle == NULL
+	       && hid_hotplug_context.pending_unregistrations > 0) {
+		if (!SleepConditionVariableCS(&hid_hotplug_context.unregistration_cv, &hid_hotplug_context.critical_section, INFINITE)) {
+			LeaveCriticalSection(&hid_hotplug_context.critical_section);
+			free(hotplug_cb);
+			register_global_winapi_error(L"hid_hotplug_register_callback/SleepConditionVariableCS");
+			return -1;
+		}
 	}
 
 	/* Start the machinery with the first callback */
@@ -1407,25 +1540,17 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 			if (hid_hotplug_context.event_work == NULL) {
 				LeaveCriticalSection(&hid_hotplug_context.critical_section);
 				free(hotplug_cb);
-				register_global_error(L"hid_hotplug_register_callback/CreateThreadpoolWork");
+				register_global_winapi_error(L"hid_hotplug_register_callback/CreateThreadpoolWork");
 				return -1;
 			}
 		}
 
-		/* Refresh the device cache: a teardown deferred to the work item may not have run yet */
-		if (hid_hotplug_context.devs != NULL) {
-			hid_free_enumeration(hid_hotplug_context.devs);
-			hid_hotplug_context.devs = NULL;
-		}
-
-		/* Fill already connected devices so we can use this info in disconnection
-		   notifications and HID_API_HOTPLUG_ENUMERATE passes (hid_enumerate also
-		   implicitly initializes the library, as if by hid_init) */
-		hid_hotplug_context.devs = hid_enumerate(0, 0);
-
 		if (hid_hotplug_context.notify_handle == NULL) {
 			GUID interface_class_guid;
-			CM_NOTIFY_FILTER notify_filter = { 0 };
+			CM_NOTIFY_FILTER notify_filter;
+			int enumerate_failure = 0;
+
+			memset(&notify_filter, 0, sizeof(notify_filter));
 
 			/* Retrieve HID Interface Class GUID
 				https://docs.microsoft.com/windows-hardware/drivers/install/guid-devinterface-hid */
@@ -1435,19 +1560,42 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 			notify_filter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
 			notify_filter.u.DeviceInterface.ClassGuid = interface_class_guid;
 
-			/* Register for a HID device notification when adding the first callback */
+			/* Register for a HID device notification when adding the first callback.
+			   Armed BEFORE the device cache is filled: a device connecting in
+			   between is then caught by the notification and deduplicated against
+			   the cache, instead of being missed by both. */
 			if (CM_Register_Notification(&notify_filter, NULL, hid_internal_notify_callback, &hid_hotplug_context.notify_handle) != CR_SUCCESS) {
 				hid_hotplug_context.notify_handle = NULL;
-				if (hid_hotplug_context.devs != NULL) {
-					hid_free_enumeration(hid_hotplug_context.devs);
-					hid_hotplug_context.devs = NULL;
-				}
 				LeaveCriticalSection(&hid_hotplug_context.critical_section);
 				free(hotplug_cb);
 				register_global_error(L"hid_hotplug_register_callback/CM_Register_Notification");
 				return -1;
 			}
+
+			/* Normally NULL already; an old notification may have appended
+			   entries between its detachment and the completion of its
+			   unregistration (or, after a failed unregistration, at any time) */
+			if (hid_hotplug_context.devs != NULL) {
+				hid_free_enumeration(hid_hotplug_context.devs);
+				hid_hotplug_context.devs = NULL;
+			}
+
+			/* Fill already connected devices so we can use this info in disconnection
+			   notifications and HID_API_HOTPLUG_ENUMERATE passes */
+			hid_hotplug_context.devs = hid_internal_enumerate(0, 0, &enumerate_failure);
+			if (enumerate_failure) {
+				/* An empty system is fine; a failed enumeration is not: the device
+				   cache and the ENUMERATE snapshot would misrepresent the system */
+				HCMNOTIFICATION notify_handle = hid_internal_hotplug_cleanup();
+				LeaveCriticalSection(&hid_hotplug_context.critical_section);
+				hid_internal_hotplug_finish_unregistration(notify_handle);
+				free(hotplug_cb);
+				/* register_global_error: set by hid_internal_enumerate */
+				return -1;
+			}
 		}
+		/* else: reuse the still-attached notification (its deferred teardown has
+		   not run yet); the device cache is kept current by that notification */
 	}
 
 	/* Take the registration-time snapshot to be replayed asynchronously
@@ -1465,7 +1613,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 				/* Tear the machinery down if this would-be-first callback was starting it */
 				notify_handle = hid_internal_hotplug_cleanup();
 				LeaveCriticalSection(&hid_hotplug_context.critical_section);
-				hid_internal_hotplug_unregister_notification(notify_handle);
+				hid_internal_hotplug_finish_unregistration(notify_handle);
 				free(hotplug_cb);
 				register_global_error(L"Failed to allocate memory for a device info snapshot");
 				return -1;
@@ -1497,6 +1645,10 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	}
 
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+
+	/* A successful registration leaves no stale error behind (the internal
+	   enumeration of an empty system registers "No HID devices found") */
+	register_global_error(NULL);
 
 	return 0;
 }
@@ -1545,7 +1697,7 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
-	hid_internal_hotplug_unregister_notification(notify_handle);
+	hid_internal_hotplug_finish_unregistration(notify_handle);
 
 	if (result != 0) {
 		register_global_error(L"Invalid or unknown hotplug callback handle");

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -246,6 +246,14 @@ struct hid_hotplug_path {
 	struct hid_hotplug_path *next;
 };
 
+/* How long (in milliseconds) the pending-arrivals list stays authoritative.
+   The duplicate arrival it suppresses was already queued by the OS when the
+   list was recorded and is delivered about as soon as the registration releases
+   the critical section, so anything this old is not that duplicate - it is a
+   genuine re-arrival on a path whose removal notification was missed (see
+   hid_internal_hotplug_take_pending_arrival). */
+#define HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS 10000
+
 static struct hid_hotplug_context {
 	/* Win32 notification handle */
 	HCMNOTIFICATION notify_handle;
@@ -276,10 +284,6 @@ static struct hid_hotplug_context {
 	/* Same failure, scoped to the teardown that has to report it (hid_exit) */
 	unsigned char unregistration_failed;
 
-	/* Set while hid_exit() is tearing the machinery down: registration and
-	   deregistration fail instead of re-arming into a context being destroyed */
-	unsigned char exiting;
-
 	/* Critical section (faster mutex substitute), for both cached device list and callback list changes */
 	CRITICAL_SECTION critical_section;
 
@@ -298,8 +302,11 @@ static struct hid_hotplug_context {
 	struct hid_device_info *devs;
 
 	/* Paths whose arrival notification may still be in flight while it has
-	   already been reported by the registration-time enumeration */
+	   already been reported by the registration-time enumeration, and the
+	   GetTickCount() timestamp of the moment they were recorded (see
+	   HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS) */
 	struct hid_hotplug_path *pending_arrivals;
+	DWORD pending_arrivals_tick;
 } hid_hotplug_context; /* zero-initialized (static storage); next_handle set on first init */
 
 static hid_device *new_hid_device()
@@ -453,14 +460,26 @@ static void register_string_error(hid_device *dev, const WCHAR *string_error)
    symbols - for every user of the library, including those that never touch
    hotplug. Everything this file uses above its minimum target is resolved
    dynamically instead (see lookup_functions and hid_internal_hotplug_resolve_threadpool).
-   The regions guarded by this lock are a handful of instructions long. */
+   The regions guarded by this lock are kept deliberately small - pointer swaps
+   and flag/counter updates; the one-time bootstrap of the hotplug machinery is
+   the largest. */
 typedef volatile LONG hid_internal_lock;
 
 static void hid_internal_lock_acquire(hid_internal_lock *lock)
 {
+	unsigned int attempts = 0;
+
 	while (InterlockedCompareExchange(lock, 1, 0) != 0) {
-		/* The holder is never descheduled for long: yield and retry */
-		Sleep(0);
+		/* Sleep(0) yields the rest of the quantum, but only to threads of equal
+		   or higher priority: if the holder is lower-priority (or starved on a
+		   single-CPU system), spinning on it can burn quanta without any
+		   progress. After a few attempts, Sleep(1) instead: it yields to any
+		   ready thread. */
+		if (++attempts < 16) {
+			Sleep(0);
+		} else {
+			Sleep(1);
+		}
 	}
 }
 
@@ -473,26 +492,47 @@ static wchar_t *last_global_error_str = NULL;
 
 /* Serializes mutations of last_global_error_str: the hotplug API is
    thread-safe and its failure paths may write the global error concurrently.
-   Note that this only protects writers against each other: HIDAPI's internal
-   event context must never write the global error at all, because hid_error(NULL)
-   hands the raw string pointer out to the application without any lock. */
+   Note that this only protects writers against each other: hid_error(NULL)
+   hands the raw string pointer out to the application without any lock, which
+   is why the header requires the application to serialize hid_error(NULL)
+   against the hotplug API. HIDAPI's own code on the internal event context
+   never writes the global error; a user callback that calls the public hotplug
+   API from the event context does, and that same serialization requirement in
+   the header covers it. */
 static hid_internal_lock global_error_lock = 0;
+
+/* Publishes a message (built by the caller, ownership taken) as the global
+   error string. Only the pointer swap is under the lock: it is a spinlock, and
+   building or freeing a message is far too heavy for a spin-guarded region. */
+static void register_global_error_message(wchar_t *msg)
+{
+	wchar_t *old_msg;
+
+	hid_internal_lock_acquire(&global_error_lock);
+	old_msg = last_global_error_str;
+	last_global_error_str = msg;
+	hid_internal_lock_release(&global_error_lock);
+
+	free(old_msg);
+}
+
+static void register_global_winapi_error_code(DWORD error_code, const WCHAR *op)
+{
+	wchar_t *msg = NULL;
+
+	register_winapi_error_code_to_buffer(&msg, op, error_code);
+	register_global_error_message(msg);
+}
 
 static void register_global_winapi_error(const WCHAR *op)
 {
-	/* Capture the error code before the lock: acquiring it may clobber it */
-	DWORD error_code = GetLastError();
-
-	hid_internal_lock_acquire(&global_error_lock);
-	register_winapi_error_code_to_buffer(&last_global_error_str, op, error_code);
-	hid_internal_lock_release(&global_error_lock);
+	/* Capture the error code first: building the message may clobber it */
+	register_global_winapi_error_code(GetLastError(), op);
 }
 
 static void register_global_error(const WCHAR *string_error)
 {
-	hid_internal_lock_acquire(&global_error_lock);
-	register_string_error_to_buffer(&last_global_error_str, string_error);
-	hid_internal_lock_release(&global_error_lock);
+	register_global_error_message(string_error ? _wcsdup(string_error) : NULL);
 }
 
 static HANDLE open_device(const wchar_t *path, BOOL open_rw)
@@ -522,11 +562,32 @@ HID_API_EXPORT const char* HID_API_CALL hid_version_str(void)
 	return HID_API_VERSION_STR;
 }
 
-/* Serializes the bootstrap of the hotplug machinery: two racing first
-   registrations must not both initialize the critical section, and every read of
-   mutex_ready that is not already made under the critical section is made under
-   this lock (it is what publishes the critical section to other threads). */
+/* Serializes the bootstrap and the teardown of the hotplug machinery (and the
+   flag and counter below): two racing first registrations must not both
+   initialize the critical section, and every read of mutex_ready that is not
+   already made under the critical section is made under this lock (it is what
+   publishes the critical section to other threads). Statically initialized:
+   guarding state with it costs no OS object. */
 static hid_internal_lock hotplug_init_lock = 0;
+
+/* Set while hid_exit() is tearing the hotplug machinery down (and unloading the
+   resolved libraries): hotplug registration and deregistration fail instead of
+   arming a context that is being destroyed, or calling into libraries that are
+   being unloaded. Guarded by hotplug_init_lock, NOT by the critical section:
+   hid_exit() must be able to raise it before it can know whether the machinery
+   (and with it the critical section) even exists - and without creating it, as
+   a program that never uses hotplug must not have hid_exit() create OS objects
+   on its behalf. */
+static LONG hotplug_exiting = 0;
+
+/* Number of threads currently counted into the hotplug machinery by
+   hid_internal_hotplug_enter, i.e. inside - or blocked on - the critical
+   section from a public hotplug call. Guarded by hotplug_init_lock.
+   hid_exit() destroys the critical section and the quiescence event only after
+   `hotplug_exiting` has cut off new entries and this count has drained to zero:
+   deleting a critical section another thread is blocked on (or about to enter)
+   is undefined behavior. */
+static LONG hotplug_machinery_users = 0;
 
 /* Resolves the threadpool API used as the hotplug event context.
    Always called inside the critical section. Returns -1 when it is unavailable
@@ -565,47 +626,105 @@ static int hid_internal_hotplug_resolve_threadpool(void)
 	return 0;
 }
 
-/* Bootstraps the hotplug machinery. The critical section and the quiescence event
-   are created once and are NEVER destroyed: they are the only things that can
-   serialize against a notification callback, and no caller - hid_exit() included -
-   can prove that no callback is about to enter them. Keeping them for the process
-   lifetime costs one critical section and one event handle, and removes an entire
-   class of use-after-free (a callback, a threadpool work item or a concurrent
-   deregistration entering a deleted critical section).
-   Returns -1 if the machinery cannot be initialized. */
-static int hid_internal_hotplug_init(void)
+/* Bootstraps the hotplug machinery: the critical section that guards all
+   hotplug state and the manual-reset quiescence event. Must be called with
+   hotplug_init_lock held. On failure nothing is created and *create_error
+   receives the CreateEvent error code (reporting it is left to the caller:
+   this runs under a spinlock).
+   Once created, the machinery stays valid for as long as anything can enter it:
+   hid_exit() destroys it only after proving nothing can (see
+   hid_internal_hotplug_enter and hid_internal_hotplug_exit), and when a
+   notification could not be unregistered it is never destroyed at all, so that
+   a live OS callback can never enter a deleted critical section. */
+static int hid_internal_hotplug_init_under_lock(DWORD *create_error)
+{
+	if (hid_hotplug_context.mutex_ready) {
+		return 0;
+	}
+
+	/* Manual reset, initially signaled: nothing is pending yet */
+	hid_hotplug_context.quiescent_event = CreateEvent(NULL, TRUE, TRUE, NULL);
+	if (hid_hotplug_context.quiescent_event == NULL) {
+		*create_error = GetLastError();
+		return -1;
+	}
+
+	InitializeCriticalSection(&hid_hotplug_context.critical_section);
+
+	hid_hotplug_context.mutex_in_use = 0;
+	hid_hotplug_context.cb_list_dirty = 0;
+	hid_hotplug_context.pending_unregistrations = 0;
+	if (hid_hotplug_context.next_handle < FIRST_HOTPLUG_CALLBACK_HANDLE)
+		hid_hotplug_context.next_handle = FIRST_HOTPLUG_CALLBACK_HANDLE;
+
+	/* Set state to Ready. Published last: a thread that observes this
+	   under hotplug_init_lock also observes everything above. */
+	hid_hotplug_context.mutex_ready = 1;
+
+	return 0;
+}
+
+/* Result codes of hid_internal_hotplug_enter (0 is success) */
+#define HID_HOTPLUG_ENTER_EXITING   1 /* hid_exit() is in progress */
+#define HID_HOTPLUG_ENTER_NOT_READY 2 /* no machinery and bootstrap not requested */
+#define HID_HOTPLUG_ENTER_FAILED    3 /* bootstrap failed (global error registered) */
+
+/* Counts the calling thread into the hotplug machinery, bootstrapping it first
+   when `bootstrap` is set. While a thread is counted in, the critical section
+   and the quiescence event exist and stay valid: hid_exit() destroys them only
+   after `hotplug_exiting` has cut off new entries AND the count has drained to
+   zero. A successful call (and only a successful call) MUST be balanced with
+   hid_internal_hotplug_leave(). */
+static int hid_internal_hotplug_enter(int bootstrap)
 {
 	int result = 0;
+	DWORD create_error = 0;
 
 	hid_internal_lock_acquire(&hotplug_init_lock);
-	if (!hid_hotplug_context.mutex_ready) {
-		/* Manual reset, initially signaled: nothing is pending yet */
-		hid_hotplug_context.quiescent_event = CreateEvent(NULL, TRUE, TRUE, NULL);
-		if (hid_hotplug_context.quiescent_event == NULL) {
-			register_global_winapi_error(L"hid_hotplug_register_callback/CreateEvent");
-			result = -1;
-		} else {
-			InitializeCriticalSection(&hid_hotplug_context.critical_section);
-
-			hid_hotplug_context.mutex_in_use = 0;
-			hid_hotplug_context.cb_list_dirty = 0;
-			hid_hotplug_context.pending_unregistrations = 0;
-			if (hid_hotplug_context.next_handle < FIRST_HOTPLUG_CALLBACK_HANDLE)
-				hid_hotplug_context.next_handle = FIRST_HOTPLUG_CALLBACK_HANDLE;
-
-			/* Set state to Ready. Published last: a thread that observes this
-			   under hotplug_init_lock also observes everything above. */
-			hid_hotplug_context.mutex_ready = 1;
-		}
+	if (hotplug_exiting) {
+		result = HID_HOTPLUG_ENTER_EXITING;
+	} else if (!bootstrap && !hid_hotplug_context.mutex_ready) {
+		result = HID_HOTPLUG_ENTER_NOT_READY;
+	} else if (hid_internal_hotplug_init_under_lock(&create_error) < 0) {
+		result = HID_HOTPLUG_ENTER_FAILED;
+	} else {
+		hotplug_machinery_users++;
 	}
 	hid_internal_lock_release(&hotplug_init_lock);
+
+	if (result == HID_HOTPLUG_ENTER_FAILED) {
+		register_global_winapi_error_code(create_error, L"hid_hotplug_register_callback/CreateEvent");
+	}
 
 	return result;
 }
 
-/* Whether the critical section exists and may be entered. Once it does, it stays
-   valid for the process lifetime (see hid_internal_hotplug_init), so the answer
-   can never go stale between the check and the EnterCriticalSection. */
+static void hid_internal_hotplug_leave(void)
+{
+	hid_internal_lock_acquire(&hotplug_init_lock);
+	hotplug_machinery_users--;
+	hid_internal_lock_release(&hotplug_init_lock);
+}
+
+/* Whether hid_exit() is currently tearing the machinery down. Re-checked under
+   the critical section by callers that were already counted in when hid_exit()
+   started: `hotplug_exiting` may be raised while they hold - or wait on - the
+   critical section, and they must not arm anything behind the teardown. */
+static int hid_internal_hotplug_exiting(void)
+{
+	int exiting;
+
+	hid_internal_lock_acquire(&hotplug_init_lock);
+	exiting = (hotplug_exiting != 0);
+	hid_internal_lock_release(&hotplug_init_lock);
+
+	return exiting;
+}
+
+/* Whether the critical section exists and may be entered. Only used by
+   hid_exit() itself (via hid_internal_hotplug_notification_leaked), on the same
+   thread that is the only one allowed to destroy the machinery, so the answer
+   cannot go stale between the check and the EnterCriticalSection. */
 static int hid_internal_hotplug_ready(void)
 {
 	int ready;
@@ -720,6 +839,8 @@ static void hid_internal_hotplug_free_pending_arrivals(void)
    replugged into the same port, so suppressing it would swallow a real connection. */
 static int hid_internal_hotplug_record_pending_arrivals(void)
 {
+	hid_hotplug_context.pending_arrivals_tick = GetTickCount();
+
 	for (struct hid_device_info *device = hid_hotplug_context.devs; device != NULL; device = device->next) {
 		struct hid_hotplug_path *entry = (struct hid_hotplug_path *)calloc(1, sizeof(struct hid_hotplug_path));
 
@@ -748,6 +869,21 @@ static int hid_internal_hotplug_record_pending_arrivals(void)
    dropped, 0 when it is a genuine new connection. */
 static int hid_internal_hotplug_take_pending_arrival(const char *path)
 {
+	/* An expired list suppresses nothing: the duplicate it exists for would have
+	   long been delivered (see HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS). Devices
+	   whose records outlive the window are devices whose removal notification
+	   was missed - consuming the record on their eventual re-arrival would
+	   swallow a genuine connection and keep the stale-record recovery in
+	   hid_internal_notify_callback from ever running. Between the two failure
+	   modes the expiry errs towards the recoverable one: a duplicate that
+	   somehow outlives the window is reported as a spurious LEFT+ARRIVED pair
+	   instead of a connection being silently dropped. */
+	if (hid_hotplug_context.pending_arrivals != NULL
+	    && GetTickCount() - hid_hotplug_context.pending_arrivals_tick > HID_HOTPLUG_PENDING_ARRIVALS_TTL_MS) {
+		hid_internal_hotplug_free_pending_arrivals();
+		return 0;
+	}
+
 	for (struct hid_hotplug_path **current = &hid_hotplug_context.pending_arrivals; *current != NULL; current = &(*current)->next) {
 		/* Case-independent path comparison is mandatory */
 		if (_stricmp((*current)->path, path) == 0) {
@@ -974,17 +1110,13 @@ static int hid_internal_hotplug_notification_leaked(void)
 	return leaked;
 }
 
-/* Ends the teardown started by hid_internal_hotplug_exit: see the `exiting` flag.
-   Called by hid_exit() once the resolved libraries are gone, too. */
+/* Ends the teardown started by hid_internal_hotplug_exit: see `hotplug_exiting`.
+   Called unconditionally by hid_exit() once the resolved libraries are gone. */
 static void hid_internal_hotplug_exit_done(void)
 {
-	if (!hid_internal_hotplug_ready()) {
-		return;
-	}
-
-	EnterCriticalSection(&hid_hotplug_context.critical_section);
-	hid_hotplug_context.exiting = 0;
-	LeaveCriticalSection(&hid_hotplug_context.critical_section);
+	hid_internal_lock_acquire(&hotplug_init_lock);
+	hotplug_exiting = 0;
+	hid_internal_lock_release(&hotplug_init_lock);
 }
 
 static int hid_internal_hotplug_exit(void)
@@ -992,24 +1124,33 @@ static int hid_internal_hotplug_exit(void)
 	HCMNOTIFICATION notify_handle;
 	PVOID event_work;
 	int failed;
+	int keep_machinery;
+	int machinery_ready;
 
-	/* Not a no-op even when hotplug was never used: `exiting` is what keeps a
-	   concurrent hid_hotplug_register_callback() - which is thread-safe, and
-	   initializes the library implicitly - from calling into hid.dll/cfgmgr32.dll
-	   while hid_exit() is unloading them. It needs the critical section to be there. */
-	if (hid_internal_hotplug_init() < 0) {
-		/* Nothing can be armed if the machinery cannot even be initialized */
+	/* Nothing may enter or arm the machinery from here on. Without this, a
+	   registration waiting for a pending unregistration to complete could wake up
+	   behind this teardown, arm a fresh notification and append a callback to a
+	   context that is being dismantled - leaving a live notification and a
+	   "registered" callback behind hid_exit(). It is also what keeps a concurrent
+	   hid_hotplug_register_callback() - which is thread-safe, and initializes the
+	   library implicitly - from calling into hid.dll/cfgmgr32.dll while hid_exit()
+	   is unloading them, and what makes the destruction at the end of this
+	   function safe. Lowered again by hid_internal_hotplug_exit_done(). */
+	hid_internal_lock_acquire(&hotplug_init_lock);
+	hotplug_exiting = 1;
+	machinery_ready = (hid_hotplug_context.mutex_ready != 0);
+	hid_internal_lock_release(&hotplug_init_lock);
+
+	if (!machinery_ready) {
+		/* Hotplug was never used (or a previous hid_exit() already destroyed the
+		   machinery): nothing can be armed, and nothing was created that would
+		   have to be freed. A registration bootstrapping the machinery right now
+		   fails on `hotplug_exiting` before it arms anything or calls into the
+		   libraries hid_exit() is about to unload. */
 		return 0;
 	}
 
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
-
-	/* Nothing may arm the machinery from here on. Without this, a registration
-	   waiting for a pending unregistration to complete could wake up behind this
-	   teardown, arm a fresh notification and append a callback to a context that
-	   is being dismantled - leaving a live notification and a "registered"
-	   callback behind hid_exit(). */
-	hid_hotplug_context.exiting = 1;
 
 	/* Remove all callbacks from the list, including their undelivered HID_API_HOTPLUG_ENUMERATE snapshots */
 	{
@@ -1044,12 +1185,16 @@ static int hid_internal_hotplug_exit(void)
 	hid_hotplug_context.unregistration_failed = 0;
 
 	event_work = hid_hotplug_context.event_work;
-	if (!failed && !hid_hotplug_context.notification_leaked) {
+	/* `failed` implies notification_leaked: they are only ever set together.
+	   Stable at this point: no unregistration is pending anymore, and nothing
+	   that could start one can enter behind `hotplug_exiting`. */
+	keep_machinery = (hid_hotplug_context.notification_leaked != 0);
+	if (!keep_machinery) {
 		hid_hotplug_context.event_work = NULL;
 	} else {
 		/* A notification may still fire and submit to the work item: keep it
-		   (deliberately leaked), along with the critical section and the device
-		   cache it works on */
+		   (deliberately leaked), along with the critical section, the quiescence
+		   event and the device cache it works on */
 		event_work = NULL;
 	}
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
@@ -1073,10 +1218,44 @@ static int hid_internal_hotplug_exit(void)
 	hid_internal_hotplug_free_pending_arrivals();
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
-	/* `exiting` stays set until hid_exit() is done unloading the libraries:
-	   see hid_internal_hotplug_exit_done.
-	   The critical section and the quiescence event are kept for the process
-	   lifetime on purpose: see hid_internal_hotplug_init */
+	if (!keep_machinery) {
+		/* hid_exit() frees what the machinery created - one kernel event and one
+		   critical section: a plugin-style host that repeatedly loads, uses and
+		   unloads the library must not accumulate OS objects. Destroying them is
+		   safe only once nothing can be inside the critical section: every
+		   notification is unregistered and the work item is drained and closed
+		   (established above), `hotplug_exiting` (still raised) keeps new callers
+		   out, so only callers already counted in remain - wait those out. They
+		   fail out promptly on their `exiting` checks. */
+		for (;;) {
+			int busy;
+
+			hid_internal_lock_acquire(&hotplug_init_lock);
+			busy = (hotplug_machinery_users != 0);
+			if (!busy) {
+				/* Unpublished under the same acquisition that proved the machinery
+				   idle: with `hotplug_exiting` raised nothing can be counted back
+				   in, so the destruction below cannot race anything. */
+				hid_hotplug_context.mutex_ready = 0;
+			}
+			hid_internal_lock_release(&hotplug_init_lock);
+
+			if (!busy) {
+				break;
+			}
+			Sleep(1);
+		}
+
+		DeleteCriticalSection(&hid_hotplug_context.critical_section);
+		CloseHandle(hid_hotplug_context.quiescent_event);
+		hid_hotplug_context.quiescent_event = NULL;
+	}
+	/* else: the machinery outlives hid_exit() on purpose - a leaked notification
+	   may still enter the critical section at any time
+	   (see hid_internal_hotplug_init_under_lock) */
+
+	/* `hotplug_exiting` stays raised until hid_exit() is done unloading the
+	   libraries: see hid_internal_hotplug_exit_done */
 
 	if (failed) {
 		register_global_error(L"hid_exit: a hotplug notification could not be unregistered");
@@ -1422,13 +1601,20 @@ end:
 	return result;
 }
 
-static char *hid_internal_UTF16toUTF8(const wchar_t *src)
+/* Returns NULL both when `src` is not valid UTF-16 and on allocation failure.
+   Callers that need to tell the two apart (an invalid string is the string's
+   problem; running out of memory is a library failure) pass `oom`, which is set
+   to 1 on allocation failure and left untouched otherwise. */
+static char *hid_internal_UTF16toUTF8(const wchar_t *src, int *oom)
 {
 	char *dst = NULL;
 	int len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, src, -1, NULL, 0, NULL, NULL);
 	if (len) {
 		dst = (char*)calloc(len, sizeof(char));
 		if (dst == NULL) {
+			if (oom) {
+				*oom = 1;
+			}
 			return NULL;
 		}
 		WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, src, -1, dst, len, NULL, NULL);
@@ -1452,7 +1638,11 @@ static wchar_t *hid_internal_UTF8toUTF16(const char *src)
 	return dst;
 }
 
-static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path, HANDLE handle)
+/* Returns NULL when the device cannot be described: because the process is out
+   of memory (`oom` - when passed - is set to 1; a library failure) or because
+   `path` is not valid UTF-16 (`oom` is left untouched; the device is simply not
+   representable and callers skip it). */
+static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path, HANDLE handle, int *oom)
 {
 	struct hid_device_info *dev = NULL; /* return object */
 	HIDD_ATTRIBUTES attrib;
@@ -1467,12 +1657,15 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 	dev = (struct hid_device_info*)calloc(1, sizeof(struct hid_device_info));
 
 	if (dev == NULL) {
+		if (oom) {
+			*oom = 1;
+		}
 		return NULL;
 	}
 
 	/* Fill out the record */
 	dev->next = NULL;
-	dev->path = hid_internal_UTF16toUTF8(path);
+	dev->path = hid_internal_UTF16toUTF8(path, oom);
 	if (dev->path == NULL) {
 		/* A record without a path is useless to the caller and unusable as the key
 		   of the hotplug device cache (where it would crash the removal lookup) */
@@ -1527,6 +1720,9 @@ static struct hid_device_info *hid_internal_get_device_info(const wchar_t *path,
 	if (dev->serial_number == NULL || dev->manufacturer_string == NULL || dev->product_string == NULL) {
 		/* Out of memory. A half-built record is not a device (and the bus-specific
 		   fixups right below dereference these strings) */
+		if (oom) {
+			*oom = 1;
+		}
 		hid_free_enumeration(dev);
 		return NULL;
 	}
@@ -1630,7 +1826,16 @@ static struct hid_device_info *hid_internal_enumerate(unsigned short vendor_id, 
 		   device to the enumeration list. */
 		if (hid_internal_match_device_id(attrib.VendorID, attrib.ProductID, vendor_id, product_id)) {
 			/* VID/PID match. Create the record. */
-			struct hid_device_info *tmp = hid_internal_get_device_info(device_interface, device_handle);
+			int oom = 0;
+			struct hid_device_info *tmp = hid_internal_get_device_info(device_interface, device_handle, &oom);
+
+			if (tmp == NULL && !oom) {
+				/* The interface path is not valid UTF-16: the device cannot be
+				   represented to the caller. Skip it - consistently with the
+				   hotplug notifications, which cannot report (or cache) such a
+				   device either, so the device cache stays in step with this list. */
+				goto cont_close;
+			}
 
 			if (tmp == NULL) {
 				/* Out of memory. Report a failure rather than a partial list: a
@@ -1693,6 +1898,47 @@ void  HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info *d
 	}
 }
 
+/* Delivers one live event to every matching callback registered at this moment.
+   Always called inside a locked mutex. Does not consume `device`. */
+static void hid_internal_hotplug_dispatch(struct hid_device_info *device, hid_hotplug_event hotplug_event)
+{
+	/* Mark the critical section as IN USE, to prevent callback removal from inside a callback */
+	hid_hotplug_context.mutex_in_use = 1;
+
+	/* Callbacks registered from inside a callback are appended to the list
+	   and see this device in their registration-time HID_API_HOTPLUG_ENUMERATE
+	   snapshot (or don't, for a removal): the live dispatch is bound to the
+	   callbacks present at event time, so the connection is reported exactly once */
+	struct hid_hotplug_callback *last_at_event = hid_hotplug_context.hotplug_cbs;
+	while (last_at_event != NULL && last_at_event->next != NULL) {
+		last_at_event = last_at_event->next;
+	}
+
+	/* Call the notifications for the device */
+	for (struct hid_hotplug_callback *callback = hid_hotplug_context.hotplug_cbs; callback != NULL; callback = callback->next) {
+		/* The registration-time enumeration pass is always delivered
+		   before any live events for the callback */
+		hid_internal_hotplug_replay_flush(callback);
+
+		if ((callback->events & hotplug_event) && hid_internal_match_device_id(device->vendor_id, device->product_id, callback->vendor_id, callback->product_id)) {
+			int result = (callback->callback)(callback->handle, device, hotplug_event, callback->user_data);
+
+			/* If the result is non-zero, we MARK the callback for future removal and proceed */
+			/* We avoid changing the list until we are done calling the callbacks to simplify the process */
+			if (result) {
+				callback->events = 0;
+				hid_hotplug_context.cb_list_dirty = 1;
+			}
+		}
+
+		if (callback == last_at_event) {
+			break;
+		}
+	}
+
+	hid_hotplug_context.mutex_in_use = 0;
+}
+
 DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context, CM_NOTIFY_ACTION action, PCM_NOTIFY_EVENT_DATA event_data, DWORD event_data_size)
 {
 	struct hid_device_info *device = NULL;
@@ -1710,7 +1956,7 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
 	if (action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL) {
-		char *path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink);
+		char *path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink, NULL);
 
 		hotplug_event = HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED;
 
@@ -1726,17 +1972,29 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 
 			/* Check validity of read_handle. */
 			if (read_handle != INVALID_HANDLE_VALUE) {
-				device = hid_internal_get_device_info(event_data->u.DeviceInterface.SymbolicLink, read_handle);
+				device = hid_internal_get_device_info(event_data->u.DeviceInterface.SymbolicLink, read_handle, NULL);
 				CloseHandle(read_handle);
 			}
 
 			if (device != NULL) {
 				/* An interface path is reused when a device is replugged into the
 				   same port, so an arrival for a path that is still cached means the
-				   removal of the previous connection was missed. Drop the stale record
-				   instead of shadowing it: a second record for the same path would
-				   never be removed, and the connection is reported as the new one it is. */
-				hid_free_enumeration(hid_internal_hotplug_take_cached_device(device->path));
+				   removal of the previous connection was missed. The previous
+				   connection is owed a DEVICE_LEFT (the header promises one for every
+				   matching device that disconnects while a callback is registered):
+				   deliver it synthetically from the stale record, then drop that
+				   record - a second record for the same path would never be removed -
+				   and report the new connection as the arrival it is. */
+				struct hid_device_info *stale_device = hid_internal_hotplug_take_cached_device(device->path);
+				if (stale_device != NULL) {
+					/* Dispatched before the new device is cached: a callback
+					   registered from inside one of these callbacks takes its
+					   HID_API_HOTPLUG_ENUMERATE snapshot from the cache, and must
+					   not see the new connection there AND as the live arrival
+					   dispatched below. */
+					hid_internal_hotplug_dispatch(stale_device, HID_API_HOTPLUG_EVENT_DEVICE_LEFT);
+					hid_free_enumeration(stale_device);
+				}
 
 				/* Append to the end of the device list */
 				if (hid_hotplug_context.devs != NULL) {
@@ -1764,7 +2022,7 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 
 		hotplug_event = HID_API_HOTPLUG_EVENT_DEVICE_LEFT;
 
-		path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink);
+		path = hid_internal_UTF16toUTF8(event_data->u.DeviceInterface.SymbolicLink, NULL);
 
 		if (path != NULL) {
 			/* The device is gone: a later arrival on the same path is a new
@@ -1779,41 +2037,7 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 	}
 
 	if (device) {
-		/* Mark the critical section as IN USE, to prevent callback removal from inside a callback */
-		hid_hotplug_context.mutex_in_use = 1;
-
-		/* Callbacks registered from inside a callback are appended to the list
-		   and see this device in their registration-time HID_API_HOTPLUG_ENUMERATE
-		   snapshot (or don't, for a removal): the live dispatch is bound to the
-		   callbacks present at event time, so the connection is reported exactly once */
-		struct hid_hotplug_callback *last_at_event = hid_hotplug_context.hotplug_cbs;
-		while (last_at_event != NULL && last_at_event->next != NULL) {
-			last_at_event = last_at_event->next;
-		}
-
-		/* Call the notifications for the device */
-		for (struct hid_hotplug_callback *callback = hid_hotplug_context.hotplug_cbs; callback != NULL; callback = callback->next) {
-			/* The registration-time enumeration pass is always delivered
-			   before any live events for the callback */
-			hid_internal_hotplug_replay_flush(callback);
-
-			if ((callback->events & hotplug_event) && hid_internal_match_device_id(device->vendor_id, device->product_id, callback->vendor_id, callback->product_id)) {
-				int result = (callback->callback)(callback->handle, device, hotplug_event, callback->user_data);
-
-				/* If the result is non-zero, we MARK the callback for future removal and proceed */
-				/* We avoid changing the list until we are done calling the callbacks to simplify the process */
-				if (result) {
-					callback->events = 0;
-					hid_hotplug_context.cb_list_dirty = 1;
-				}
-			}
-
-			if (callback == last_at_event) {
-				break;
-			}
-		}
-
-		hid_hotplug_context.mutex_in_use = 0;
+		hid_internal_hotplug_dispatch(device, hotplug_event);
 
 		/* Free removed device */
 		if (hotplug_event == HID_API_HOTPLUG_EVENT_DEVICE_LEFT) {
@@ -1834,61 +2058,21 @@ DWORD WINAPI hid_internal_notify_callback(HCMNOTIFICATION notify, PVOID context,
 	return ERROR_SUCCESS;
 }
 
-int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short vendor_id, unsigned short product_id, int events, int flags, hid_hotplug_callback_fn callback, void* user_data, hid_hotplug_callback_handle* callback_handle)
+/* The registration steps that run inside the machinery. The caller has already
+   counted itself in with hid_internal_hotplug_enter - which is what keeps the
+   critical section alive for the whole call - and balances that with
+   hid_internal_hotplug_leave afterwards. Takes ownership of hotplug_cb: it is
+   freed on failure. */
+static int hid_internal_hotplug_register_counted(struct hid_hotplug_callback *hotplug_cb, int flags, hid_hotplug_callback_handle *callback_handle)
 {
-	struct hid_hotplug_callback* hotplug_cb;
-
-	/* No events can be delivered before the handle is written */
-	if (callback_handle != NULL) {
-		*callback_handle = 0;
-	}
-
-	/* Check params */
-	if (callback == NULL) {
-		register_global_error(L"Callback function is NULL");
-		return -1;
-	}
-	if (events == 0
-		|| (events & ~(HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT))) {
-		register_global_error(L"Invalid events mask");
-		return -1;
-	}
-	if (flags & ~(HID_API_HOTPLUG_ENUMERATE)) {
-		register_global_error(L"Invalid flags");
-		return -1;
-	}
-
-	hotplug_cb = (struct hid_hotplug_callback*)calloc(1, sizeof(struct hid_hotplug_callback));
-
-	if (hotplug_cb == NULL) {
-		register_global_error(L"Failed to allocate memory for a hotplug callback");
-		return -1;
-	}
-
-	/* Fill out the record */
-	hotplug_cb->next = NULL;
-	hotplug_cb->vendor_id = vendor_id;
-	hotplug_cb->product_id = product_id;
-	hotplug_cb->events = events;
-	hotplug_cb->user_data = user_data;
-	hotplug_cb->callback = callback;
-	hotplug_cb->replay = NULL;
-
-	/* Ensure we are ready to actually use the mutex */
-	if (hid_internal_hotplug_init() < 0) {
-		/* register_global_error: set by hid_internal_hotplug_init */
-		free(hotplug_cb);
-		return -1;
-	}
-
 	/* Lock the mutex to avoid race conditions */
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
 	for (;;) {
-		if (hid_hotplug_context.exiting) {
-			/* hid_exit() is tearing the machinery down: arming it again behind its
-			   back would leave a live notification and a registered callback with no
-			   context to run in */
+		if (hid_internal_hotplug_exiting()) {
+			/* hid_exit() started tearing the machinery down after this call was
+			   counted in: arming it again behind its back would leave a live
+			   notification and a registered callback with no context to run in */
 			register_global_error(L"hid_exit() is in progress");
 			LeaveCriticalSection(&hid_hotplug_context.critical_section);
 			free(hotplug_cb);
@@ -1905,7 +2089,12 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 
 		/* The unregistration completes on another thread (or on the event context),
 		   which needs the critical section, so the wait must not hold it. On wake the
-		   state is re-evaluated from scratch. */
+		   state is re-evaluated from scratch.
+		   This LeaveCriticalSection releases the critical section completely only
+		   because it cannot be held recursively here: on the event context (the one
+		   place this function runs with the critical section already held, via a
+		   user callback registering a callback) hotplug_cbs is never NULL, so the
+		   loop has already exited above. */
 		LeaveCriticalSection(&hid_hotplug_context.critical_section);
 		if (WaitForSingleObject(hid_hotplug_context.quiescent_event, INFINITE) == WAIT_FAILED) {
 			register_global_winapi_error(L"hid_hotplug_register_callback/WaitForSingleObject");
@@ -2019,10 +2208,10 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 
 	/* Take the registration-time snapshot to be replayed asynchronously
 	   on the event context, one exact copy per matching connected device */
-	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
+	if ((flags & HID_API_HOTPLUG_ENUMERATE) && (hotplug_cb->events & HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
 		struct hid_device_info **replay_tail = &hotplug_cb->replay;
 		for (struct hid_device_info *device = hid_hotplug_context.devs; device != NULL; device = device->next) {
-			if (!hid_internal_match_device_id(device->vendor_id, device->product_id, vendor_id, product_id)) {
+			if (!hid_internal_match_device_id(device->vendor_id, device->product_id, hotplug_cb->vendor_id, hotplug_cb->product_id)) {
 				continue;
 			}
 			*replay_tail = hid_internal_copy_device_info(device);
@@ -2074,12 +2263,82 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short ven
 	return 0;
 }
 
+int HID_API_EXPORT HID_API_CALL hid_hotplug_register_callback(unsigned short vendor_id, unsigned short product_id, int events, int flags, hid_hotplug_callback_fn callback, void* user_data, hid_hotplug_callback_handle* callback_handle)
+{
+	struct hid_hotplug_callback* hotplug_cb;
+	int result;
+
+	/* No events can be delivered before the handle is written */
+	if (callback_handle != NULL) {
+		*callback_handle = 0;
+	}
+
+	/* Check params */
+	if (callback == NULL) {
+		register_global_error(L"Callback function is NULL");
+		return -1;
+	}
+	if (events == 0
+		|| (events & ~(HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED | HID_API_HOTPLUG_EVENT_DEVICE_LEFT))) {
+		register_global_error(L"Invalid events mask");
+		return -1;
+	}
+	if (flags & ~(HID_API_HOTPLUG_ENUMERATE)) {
+		register_global_error(L"Invalid flags");
+		return -1;
+	}
+
+	hotplug_cb = (struct hid_hotplug_callback*)calloc(1, sizeof(struct hid_hotplug_callback));
+
+	if (hotplug_cb == NULL) {
+		register_global_error(L"Failed to allocate memory for a hotplug callback");
+		return -1;
+	}
+
+	/* Fill out the record */
+	hotplug_cb->next = NULL;
+	hotplug_cb->vendor_id = vendor_id;
+	hotplug_cb->product_id = product_id;
+	hotplug_cb->events = events;
+	hotplug_cb->user_data = user_data;
+	hotplug_cb->callback = callback;
+	hotplug_cb->replay = NULL;
+
+	/* Ensure the machinery is ready to be used, and keep hid_exit() from
+	   destroying it while this call is inside */
+	switch (hid_internal_hotplug_enter(1 /* bootstrap on first use */)) {
+	case 0:
+		break;
+	case HID_HOTPLUG_ENTER_EXITING:
+		/* hid_exit() is tearing the machinery down: arming it again behind its
+		   back would leave a live notification and a registered callback with no
+		   context to run in */
+		register_global_error(L"hid_exit() is in progress");
+		free(hotplug_cb);
+		return -1;
+	default:
+		/* register_global_error: set by hid_internal_hotplug_enter */
+		free(hotplug_cb);
+		return -1;
+	}
+
+	result = hid_internal_hotplug_register_counted(hotplug_cb, flags, callback_handle);
+
+	hid_internal_hotplug_leave();
+
+	return result;
+}
+
 int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_callback_handle callback_handle)
 {
 	int result = -1;
 	HCMNOTIFICATION notify_handle;
 
-	if (callback_handle <= 0 || !hid_internal_hotplug_ready()) {
+	/* Never bootstraps the machinery: with no machinery there is nothing this
+	   handle could belong to. And when hid_exit() is in progress, it deregisters
+	   every callback and invalidates every handle - this one is (or is about to
+	   be) one of them. */
+	if (callback_handle <= 0 || hid_internal_hotplug_enter(0) != 0) {
 		register_global_error(L"Invalid or unknown hotplug callback handle");
 		return -1;
 	}
@@ -2087,11 +2346,12 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 	/* Lock the mutex to avoid race conditions */
 	EnterCriticalSection(&hid_hotplug_context.critical_section);
 
-	if (hid_hotplug_context.exiting) {
-		/* hid_exit() deregisters every callback and invalidates every handle:
-		   this one is (or is about to be) one of them */
+	if (hid_internal_hotplug_exiting()) {
+		/* hid_exit() started tearing the machinery down after this call was
+		   counted in: same as above */
 		register_global_error(L"Invalid or unknown hotplug callback handle");
 		LeaveCriticalSection(&hid_hotplug_context.critical_section);
+		hid_internal_hotplug_leave();
 		return -1;
 	}
 
@@ -2133,6 +2393,8 @@ int HID_API_EXPORT HID_API_CALL hid_hotplug_deregister_callback(hid_hotplug_call
 	LeaveCriticalSection(&hid_hotplug_context.critical_section);
 
 	hid_internal_hotplug_finish_unregistration(notify_handle);
+
+	hid_internal_hotplug_leave();
 
 	return result;
 }
@@ -2250,7 +2512,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 	dev->input_report_length = caps.InputReportByteLength;
 	dev->feature_report_length = caps.FeatureReportByteLength;
 	dev->read_buf = (char*) malloc(dev->input_report_length);
-	dev->device_info = hid_internal_get_device_info(interface_path, dev->device_handle);
+	dev->device_info = hid_internal_get_device_info(interface_path, dev->device_handle, NULL);
 
 end_of_function:
 	free(interface_path);


### PR DESCRIPTION
Implements the hotplug contract documented via #790 for the **windows** backend (`windows/hid.c` only).

## What changed

- **Asynchronous ENUMERATE pass.** `hid_hotplug_register_callback` no longer runs the `HID_API_HOTPLUG_ENUMERATE` pass synchronously on the calling thread. Instead it takes a deep-copied snapshot of the matching entries of the cached device list (under the hotplug critical section, only when the flag is set and `events` includes `DEVICE_ARRIVED`) into a per-callback `replay` list, and submits a threadpool work item (`CreateThreadpoolWork`/`SubmitThreadpoolWork`) that delivers it on the same critical-section-serialized context that delivers live `CM_Register_Notification` events. The pass never fires from within `register` itself and never on an application thread.
- **Exactly once, pass-before-live.** Live dispatch flushes a callback's pending replay before delivering any live event to it, and is bounded to the callbacks present at event time, so a callback registered from inside another callback picks the in-flight device up from its snapshot rather than from the live loop (previously it could see it twice). `device->next` is now `NULL` for every invocation, including the synthetic ones (the old sync pass handed out devices still linked into the cached list).
- **Callback return value honored during the pass** (#793, windows): a non-zero return stops the remainder of the pass, frees the undelivered snapshot and deregisters the callback.
- **Deregister return value**: `0` only when the handle was found and deregistered; `-1` for unknown, stale or already-self-deregistered handles (safe no-op).
- **Error strings**: all register/deregister failure paths (including argument validation) set the global error retrievable via `hid_error(NULL)`; `*callback_handle` is zeroed on any registration failure.
- **Teardown safety**: `CM_Unregister_Notification` is documented to deadlock when called from its own notification callback, and it also deadlocks if called while holding a lock the notification callback takes. The teardown now detaches the notification handle under the critical section and unregisters outside it; when the last callback removes itself from inside the notification callback, the actual teardown is deferred to the threadpool work item. `hid_exit` frees undelivered snapshots, waits for in-flight work items (`WaitForThreadpoolWorkCallbacks`) before deleting the critical section, and sweeps anything a last-gasp notification appended to the device cache.

## Design notes

- The work item is a single reusable `PTP_WORK` created with the first callback registration and closed by `hid_exit`. I used `CreateThreadpoolWork` rather than `TrySubmitThreadpoolCallback` because teardown needs `WaitForThreadpoolWorkCallbacks` to guarantee no work item can touch the critical section after `hid_exit` deletes it; the fire-and-forget API offers no way to wait.
- Replay flushing is idempotent and runs under the critical section with `mutex_in_use` set: whichever of the work item or a live event acquires the lock first delivers the pass, the other finds `replay == NULL`.
- Registration reuses an already-registered CM notification when a deferred teardown has not run yet (and refreshes the cached device list), instead of failing as the old code did.
- The threadpool API needs Vista-level declarations, so the file now raises `_WIN32_WINNT` to `0x0600` when it is set lower (the dynamically-resolved CM notification API already requires Windows 8 at runtime).

Addresses #793 for the windows backend.

Assisted-by: claude-code:claude-fable-5

## Review round 1

Reviewed independently by two reviewers against the #790 contract; all confirmed findings are addressed in `a3350c4`:

- **Enumerate-before-subscribe blind window** (blocker) вЂ” the CM notification is now armed *before* the registration-time snapshot, and arrivals are deduplicated by path in the notification callback, so a device connecting between the two is caught by the notification and absorbed by the dedupe instead of being reported by neither.
- **Detached-but-live notification vs a fresh registration**, and **cache refresh during a deferred teardown** вЂ” arming a new notification now waits for in-flight `CM_Unregister_Notification` calls to complete (pending counter + condition variable), and the device cache is rebuilt only when a notification is actually being armed. Both windows could previously deliver one connection twice.
- **`hid_exit` racing a concurrent deregister** вЂ” the same quiescence gate is awaited before destroying state (previously it could `DeleteCriticalSection` / `CloseThreadpoolWork` while a detached notification was still live at the OS). A *failed* `CM_Unregister_Notification` now poisons the epoch: `hid_exit` reports the failure and deliberately leaks the critical section, work item and DLL handles rather than let a live notification touch destroyed state.
- **Initialization and error-reporting races** вЂ” the machinery bootstrap is guarded by a statically-initialized `SRWLOCK` (two racing first registrations could both initialize the critical section), and all mutations of the global error string are serialized by another `SRWLOCK` (concurrent failures in the documented-thread-safe register/deregister could double-free it).
- **Enumeration failure vs empty system** вЂ” the two are now distinguished (registration fails on genuine failure), and the stale "No HID devices found" error is cleared on successful registration.
- **Handle exhaustion** вЂ” registration now fails with an error instead of signed-overflowing and wrapping onto live handles.
- **C++ cleanliness** вЂ” `{ 0 }` struct initializers replaced with `memset` for `-Wmissing-field-initializers` under GNU C++.


## Review round 2

Reviewed independently by two further reviewers; all confirmed findings are addressed in `1f621c1`:

- **Critical section lifetime** (blocker) вЂ” `hid_exit` deleted the critical section with no lock held across the teardown, while a registration sleeping on a pending unregistration, a concurrent (contract-legal) deregistration, or `hid_internal_hotplug_init` could still be about to enter it. The critical section and the quiescence event are now created once and **never destroyed** (consistent with the leaked-notification path, which already had to keep them), and an explicit `exiting` state, set under the lock, makes registration and deregistration fail rather than arm a notification behind a teardown. `mutex_ready` is only ever read under the bootstrap lock or under the critical section itself.
- **`hid_exit` unloading the DLLs under a concurrent registration** вЂ” found by the new stress test. `hid_hotplug_register_callback` is thread-safe and initializes the library implicitly, so it could be calling `CM_Register_Notification` through a function pointer while `hid_exit` was `FreeLibrary`-ing `cfgmgr32.dll`. `exiting` is now held across the unload; every other call through those pointers is either made under the critical section or accounted for by the pending-unregistration counter that the teardown waits out.
- **Global error string written from an internal thread** вЂ” `hid_error(NULL)` returns the raw string pointer with no lock, so the threadpool work item reporting a failed `CM_Unregister_Notification` could `free()` it under an application thread: a use-after-free the application cannot serialize away. HIDAPI's internal event context no longer writes the global error at all; the failure is recorded in internal state and reported by the next `hid_exit`. The writer-side lock (round 1) is kept for the application-thread writers.
- **Poisoned epoch was permanent and re-armable** вЂ” the failure is now scoped to the `hid_exit` that reports it (a single failed unregistration no longer makes every later `hid_exit` return -1), while the safety consequences stay for the process: the state a live notification can reach is never destroyed, the DLLs it calls into are never unloaded, the module that contains the callback is **pinned** (`GetModuleHandleEx`), and **no second notification is ever armed** next to it вЂ” registration fails with an explicit error, because two live registrations would deliver every event twice.
- **Path dedupe was permanent** вЂ” an interface path is reused when a device is replugged into the same port, so deduplicating every arrival against the cache could swallow a genuine new connection. The dedupe now covers only the window it exists for (the overlap between arming the notification and taking the registration-time snapshot): the enumerated paths are recorded, each swallows at most one arrival, and a path is dropped as soon as its device leaves. Outside that window an arrival for a cached path is a new connection and replaces the stale record instead of being shadowed by it.
- **OOM handling in the enumeration** вЂ” a per-device allocation failure was treated as a successful (but silently short) enumeration, so a registration could succeed with devices missing from the pass; it now goes through the failure channel. A `hid_device_info` is never handed out half-built, so the hotplug cache can no longer hold a record with a `NULL` path вЂ” which the removal walk dereferenced вЂ” and the bus-specific fixups (`hid_internal_get_usb_info`/`_get_ble_info`, which `wcslen()` the strings) can no longer read a `NULL`.
- **`_WIN32_WINNT` force-bump removed** (supersedes the round-1 design note) вЂ” it turned the threadpool, `SRWLOCK` and condition-variable calls into load-time Vista-only imports of `hidapi.dll` for *every* user, including those that never touch hotplug, and it contradicted the file's `LoadLibrary`/`GetProcAddress` discipline. The four threadpool entry points are now resolved from `kernel32` like everything else (hotplug registration fails with an error if they are unavailable), and the two Vista-only synchronisation primitives were replaced with equivalents that need no initialization (the quiescence wait is a manual-reset event; the two tiny writer locks are interlocked locks). `dumpbin /imports` on the resulting DLL shows no `*Threadpool*`, `*SRWLock*` or `*ConditionVariable*` symbols.

Verified with the CI recipes (MSVC C and C++, `/W4 /WX`, ASAN), the repo's ctest suite, and a throwaway white-box contract test (synthetic CM notifications + allocation fault injection) covering the async pass semantics, non-zero return, self-deregistration, register-from-callback, stale handles, `hid_exit` with a pending replay, re-init, argument validation, `hid_exit` racing register/deregister storms, replug-on-the-same-path, `NULL`-path cache records and 400 OOM injection points вЂ” 10x stress runs, all green.



## Review round 3

A delta review of `1f621c1` (read **and executed**: MSVC C and C++20 `/W4 /WX` builds, `dumpbin /imports`, a DLL load/unload handle-leak harness, and a 6-thread register/deregister storm racing `hid_exit`) confirmed the round-2 synchronization model holds, and found one newly-introduced blocker plus several minors; all are addressed in `0ddecf2`:

- **`hid_exit` leaked a kernel event and a critical section for every user** (blocker, introduced by round 2) вЂ” round 2 made `hid_exit` bootstrap the hotplug machinery just to raise the `exiting` flag, and the never-destroy policy then guaranteed the event handle and the critical section were never freed: a plain `hid_init`/`hid_enumerate`/`hid_exit` program that never touches hotplug leaked one handle per load/use/unload cycle (measured: **+100 handles over 100 cycles**), contradicting `hid_exit`'s documented purpose. The flag now lives under the statically-initialized bootstrap spinlock вЂ” which costs no OS object вЂ” so `hid_exit` can raise it without creating anything and return early when the machinery never existed. On top of that, every public hotplug call is now *counted into* the machinery under that same lock, which supplies the proof round 2 lacked: once `exiting` cuts off new entries, every notification is unregistered, the work item is drained and closed, and the user count is zero, nothing can be inside вЂ” or blocked on вЂ” the critical section, so the clean path of `hid_exit` now **destroys** the event and critical section it created. The leaked-notification path keeps everything alive forever, exactly as before. Measured after the fix: **0 handle growth over 100 cycles, with and without hotplug use in the loop** (was +100 in both).
- **Stale pending-arrival records swallowed genuine re-arrivals** вЂ” the registration-time dedupe records suppressed the one in-flight duplicate they exist for, but a record whose duplicate never came outlived that window; if the device's *removal* notification was then missed, its genuine re-arrival was consumed by its own stale record, and the stale-record recovery could never run for exactly the devices it targets. The list now expires (10 s, far beyond any notification delivery latency): the failure modes are asymmetric in the right direction вЂ” an over-aged duplicate would produce a spurious left+arrived pair instead of a silently dropped connection.
- **Stale-record replacement owed a `DEVICE_LEFT`** вЂ” replacing a stale cache record on a same-path arrival reported the new connection but silently discarded the previous one, although the header promises a "left" event for every matching device that disconnects while a callback is registered. The live dispatch loop is factored out (`hid_internal_hotplug_dispatch`) and the stale record is now delivered as a synthetic `DEVICE_LEFT` before the new device is cached, preserving exactly-once for callbacks registered from within a callback.
- **Spinlock discipline** вЂ” the global error message is now built and freed *outside* the internal spinlock (only the pointer swap is guarded; previously `FormatMessageW` plus `free`/`calloc` ran under it), and the acquire loop escalates from `Sleep(0)` to `Sleep(1)` after a few attempts: `Sleep(0)` yields only to equal-or-higher-priority threads, so spinning against a lower-priority holder on a single CPU made no progress until the balance-set manager intervened.
- **One malformed interface path failed the whole enumeration as an OOM** вЂ” `hid_internal_UTF16toUTF8` returns `NULL` both for invalid UTF-16 (e.g. an unpaired surrogate) and on allocation failure, and round 2 escalated both to a full-enumeration failure reported as "Failed to allocate memory". The two are now distinguished: an unrepresentable device is skipped (consistently with the hotplug notifications, which can neither report nor cache it), and only genuine allocation failures abort the pass.
- Also: corrected the comment on the global error lock (a user callback calling the public hotplug API from the event context *does* write the global error; the header's serialization requirement covers it), removed a dead `failed` term the sticky `notification_leaked` flag always implies, and documented why the registration wait loop may release the critical section unconditionally (it can never be held recursively there).

Verified with the CI recipes (MSVC C and C++20, `/W4 /WX`, ASAN, plus the `HIDAPI_USE_DDK` compile), `dumpbin /imports` (still no `*Threadpool*`/`*SRWLock*`/`*ConditionVariable*` imports; the only new kernel32 import is `GetTickCount`), the handle-leak harness above, and the white-box contract test extended with the new cases (pending-arrival expiry, missed-removal recovery delivering left+arrived, invalid-UTF-16 vs OOM) вЂ” including 3x runs of the 8-second 6-thread `hid_exit` race, all green.

---

### Final state (after review) — supersedes parts of the description above

The pending-arrival / wall-clock-expiry / missed-removal-recovery scheme described earlier was **removed**. The final design: arrival de-duplication and removal are an **allocation-free** live-cache path comparison (a hand-rolled, surrogate-validated UTF-16↔UTF-8 compare), so an OOM on the removal path can never leave the cache stale; the four threadpool APIs are resolved dynamically via `GetProcAddress` (keeping the DLL's load-time OS floor at XP — no static Vista-only imports); a user-count enter/leave gate lets `hid_exit()` prove no thread is inside or blocked on the critical section before destroying it (0 leaked handles for programs that never touch hotplug); and internal-event-context writes to the global error string are suppressed via a thread-local flag.

**Verification.** Every fix commit on this branch was adversarially delta-verified by an independent reviewer (Codex on a separate plan, or a fresh model) tasked to find what the fix itself broke — a loop that caught a defect in nearly every fix commit. A per-backend white-box harness injects fake device events into the real implementation and runs under ASan/UBSan/LSan and TSan (TSan proven live). The `hotplug-integration` branch — all four final backends merged with the test suite (#826) — is CI-green on every platform, with the hotplug contract tests **executing** against this backend, not skipped.

Addresses the Windows `register_callback` error-handling review (#785) and implements `device->next == NULL` (#791, #792) and the ENUMERATE return-value (#793) contract for winapi. Part of hotplug support (#238); contract documented in #790.

Assisted-by: claude-code:claude-opus-4-8
